### PR TITLE
Add handling for SPIR-V target

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -1498,6 +1498,10 @@ actual:\n\
             let mut fname = f.file_name().unwrap().to_os_string();
             fname.push(".js");
             f.set_file_name(&fname);
+        } else if self.config.target.contains("spirv") {
+            let mut fname = f.file_name().unwrap().to_os_string();
+            fname.push(".spv");
+            f.set_file_name(&fname);
         } else if self.config.target.contains("wasm32") {
             let mut fname = f.file_name().unwrap().to_os_string();
             fname.push(".wasm");


### PR DESCRIPTION
We're trying to use compiletest in `rust-gpu`, and we ran into an issue where errors from `spirv-val` include the binary file name with a file extension being platform dependent. This change fixes that. I've already upstreamed this change `rust-lang/rust`, but it seems the codebase in `rust` has changed quite a bit that I couldn't easily update `compiletest-rs` to the latest `master`.

I don't know if it's preferable to just port this one change or wait till the next update to `master`. I could share my in progress branch of of updating `compiletest`, it compiles but it's failing the tests, something about how things get output changed that I didn't figure out yet. I'd happy to work on it, as I'd really like to get this change as using `compiletest` really speeds up our tests, like from minutes to seconds 🙂 