### PR TITLE
Partially sync `normalize_output` to upstream, for `$TEST_BUILD_DIR` support.

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -2595,17 +2595,30 @@ actual:\n\
     }
 
     fn normalize_output(&self, output: &str, custom_rules: &[(String, String)]) -> String {
-        let parent_dir = self.testpaths.file.parent().unwrap();
         let cflags = self.props.compile_flags.join(" ");
-        let json = cflags.contains("--error-format json") ||
-                   cflags.contains("--error-format pretty-json");
-        let parent_dir_str = if json {
-            parent_dir.display().to_string().replace("\\", "\\\\")
-        } else {
-            parent_dir.display().to_string()
+        let json = cflags.contains("--error-format json")
+            || cflags.contains("--error-format pretty-json")
+            || cflags.contains("--error-format=json")
+            || cflags.contains("--error-format=pretty-json")
+            || cflags.contains("--output-format json")
+            || cflags.contains("--output-format=json");
+
+        let mut normalized = output.to_string();
+
+        let mut normalize_path = |from: &Path, to: &str| {
+            let mut from = from.display().to_string();
+            if json {
+                from = from.replace("\\", "\\\\");
+            }
+            normalized = normalized.replace(&from, to);
         };
 
-        let mut normalized = output.replace(&parent_dir_str, "$DIR");
+        let parent_dir = self.testpaths.file.parent().unwrap();
+        normalize_path(parent_dir, "$DIR");
+
+        // Paths into the build directory
+        let test_build_dir = &self.config.build_base;
+        normalize_path(test_build_dir, "$TEST_BUILD_DIR");
 
         if json {
             // escaped newlines in json strings should be readable


### PR DESCRIPTION
I've effectively copied this part of the upstream `compiletest`: https://github.com/rust-lang/rust/blob/41b315a470d583f6446599984ff9ad3bd61012b2/src/tools/compiletest/src/runtest.rs#L3581-L3626

But only kept these path normalizations:
* `$DIR`
* `$TEST_BUILD_DIR`

Upstream also has these, that I removed (as they only make sense in the context of building Rust itself):
* `$SRC_DIR = ${config.src_base}/../../../library` (where `../../..` strips e.g. `src/test/ui`)
* `$BUILD_DIR = $TEST_BUILD_DIR/../../..` (where `../../..` strips e.g. `x86_64-unknown-linux-gnu/test/ui`)
* `$LIB_DIR = $BUILD_DIR/../lib` (where `..` strips `build`, but AFAICT top-level `lib` never existed?!)

~~**EDIT**: made this into a draft because something is missing for windows support - see [this CI failure](https://github.com/EmbarkStudios/rust-gpu/pull/512/checks?check_run_id=2156506213#step:8:532).~~
**EDIT2**: false alarm, it was caused by diagnostics printing paths with `{:?}`, which causes `\\` on windows.