### PR TITLE
Normalize $SRC_DIR

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -2616,6 +2616,10 @@ actual:\n\
         let parent_dir = self.testpaths.file.parent().unwrap();
         normalize_path(parent_dir, "$DIR");
 
+        let src_dir_str = std::env::current_dir().unwrap();
+        let src_dir = Path::new(&src_dir_str);
+        normalize_path(src_dir, "$SRC_DIR");
+
         // Paths into the build directory
         let test_build_dir = &self.config.build_base;
         normalize_path(test_build_dir, "$TEST_BUILD_DIR");

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -2616,9 +2616,10 @@ actual:\n\
         let parent_dir = self.testpaths.file.parent().unwrap();
         normalize_path(parent_dir, "$DIR");
 
-        let src_dir_str = std::env::current_dir().unwrap();
-        let src_dir = Path::new(&src_dir_str);
-        normalize_path(src_dir, "$SRC_DIR");
+        if let Ok(src_dir_str) = std::env::var("CARGO_MANIFEST_DIR") {
+            let src_dir = Path::new(&src_dir_str);
+            normalize_path(src_dir, "$SRC_DIR");
+        }
 
         // Paths into the build directory
         let test_build_dir = &self.config.build_base;


### PR DESCRIPTION
This change normalizes absolute paths for the crate manifest directory to `$SRC_DIR`. 

This closes #198. 

In that issue, it was discussed that it is difficult to determine the correct manifest directory. I'm not sure exactly the semantics of the working directory when `normalize_output` is executed, but it was reliably the manifest directory in all of my testing (running Cargo from many different directories in a large Cargo workspace). 