### PR TITLE
Support `// only-*` and increase `// {only,ignore}-*` flexibility.

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -589,6 +589,7 @@ impl Config {
                 name == util::get_pointer_width(&self.target) ||    // pointer width
                 name == self.stage_id.split('-').next().unwrap() || // stage
                 Some(name) == util::get_env(&self.target) ||        // env
+                self.target.ends_with(name) ||                      // target and env
                 match self.mode {
                     common::DebugInfoGdb => name == "gdb",
                     common::DebugInfoLldb => name == "lldb",

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,15 +65,15 @@ pub fn matches_os(triple: &str, name: &str) -> bool {
             return os == name;
         }
     }
-    panic!("Cannot determine OS from triple");
+    false
 }
-pub fn get_arch(triple: &str) -> &'static str {
+pub fn get_arch(triple: &str) -> &str {
     for &(triple_arch, arch) in ARCH_TABLE {
         if triple.contains(triple_arch) {
             return arch;
         }
     }
-    panic!("Cannot determine Architecture from triple");
+    triple.split('-').nth(0).unwrap()
 }
 
 pub fn get_env(triple: &str) -> Option<&str> {


### PR DESCRIPTION
The first two commits are selective backports of upstream features:
1. [`// only-*` support](https://github.com/rust-lang/rust/blob/3802025f400af7817ba4874587e6a2df95abd65d/src/tools/compiletest/src/header.rs#L897-L902) + the [`has_cfg_prefix` helper](https://github.com/rust-lang/rust/blob/3802025f400af7817ba4874587e6a2df95abd65d/src/tools/compiletest/src/header.rs#L715-L720) it uses
2. [letting `// {only,ignore}-*` match any triple suffix](https://github.com/rust-lang/rust/blob/3802025f400af7817ba4874587e6a2df95abd65d/src/tools/compiletest/src/header.rs#L688)

The last commit doesn't match an upstream change, but it's the smallest delta I can manage given the state of the code - I think upstream needs a refactor in that area.

It has [long OS and arch name lists](https://github.com/rust-lang/rust/blob/3802025f400af7817ba4874587e6a2df95abd65d/src/tools/compiletest/src/util.rs#L11-L86) but the intent looks to be to provide shorter aliases for *some* of them, rather than be a strict allowlist.

We hit the panics this PR removes in Rust-GPU, and it seems more sensible to have some default behavior rather than hardcode Rust-GPU's needs into this project.