### PR TITLE
Replace use of renamed -Zno-trans with -Zno-codegen

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -397,7 +397,7 @@ actual:\n\
         let aux_dir = self.aux_output_dir_name();
 
         rustc.arg("-")
-            .arg("-Zno-trans")
+            .arg("-Zno-codegen")
             .arg("--out-dir").arg(&out_dir)
             .arg(&format!("--target={}", target))
             .arg("-L").arg(&self.config.build_base)


### PR DESCRIPTION
This is for compatibility with the current version of the compiler, where using the `Pretty` mode produces an error from `rustc`.

```
error: unknown debugging option: `no-trans`
```