### PR TITLE
Add Loongarch64 support

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -41,6 +41,7 @@ const ARCH_TABLE: &'static [(&'static str, &'static str)] = &[
     ("i386", "x86"),
     ("i586", "x86"),
     ("i686", "x86"),
+    ("loongarch64", "loongarch64"),
     ("mips", "mips"),
     ("msp430", "msp430"),
     ("nvptx64", "nvptx64"),


### PR DESCRIPTION
The LoongArch architecture  is an Instruction Set Architecture (ISA) that has a Reduced Instruction Set Computer (RISC) style.
The Loongarch doc: https://loongson.github.io/LoongArch-Documentation/README-EN.html