### PR TITLE
Use the revision filename when compiling the rustfix output

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -2408,10 +2408,13 @@ actual:\n\
             // And finally, compile the fixed code and make sure it both
             // succeeds and has no diagnostics.
             let mut rustc = self.make_compile_args(
-                &self.testpaths.file.with_extension(UI_FIXED),
+                &expected_fixed_path,
                 TargetLocation::ThisFile(self.make_exe_name()),
                 AllowUnused::No,
             );
+            // Set the crate name to avoid `file.revision.fixed` inferring the
+            // invalid name `file.revision`
+            rustc.arg("--crate-name=fixed");
             rustc.arg("-L").arg(&self.aux_output_dir_name());
             let res = self.compose_and_run_compiler(rustc, None);
             if !res.status.success() {


### PR DESCRIPTION
Currently for a file with revisions, `file.fixed` is compiled instead of `file.revision.fixed`

e.g. [`manual_assert.rs`](https://github.com/rust-lang/rust-clippy/blob/master/tests/ui/manual_assert.rs) checks [`manual_assert.fixed`](https://github.com/rust-lang/rust-clippy/blob/master/tests/ui/manual_assert.fixed) instead of [`manual_assert.edition2018.fixed`](https://github.com/rust-lang/rust-clippy/blob/master/tests/ui/manual_assert.edition2018.fixed) and [`manual_assert.edition2021.fixed`](https://github.com/rust-lang/rust-clippy/blob/master/tests/ui/manual_assert.edition2021.fixed)