### PR TITLE
json: Remove unused `explanation` field from `DiagnosticCode`

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -68,8 +68,6 @@ struct DiagnosticSpanMacroExpansion {
 struct DiagnosticCode {
     /// The code itself.
     code: String,
-    /// An explanation for the code.
-    explanation: Option<String>,
 }
 
 pub fn extract_rendered(output: &str, proc_res: &ProcRes) -> String {


### PR DESCRIPTION
It doesn't exist in the upstream Rust repo either.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>