### PR TITLE
Require an `@` in front of all commands.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -229,6 +229,11 @@ pub struct Config {
     /// The default Rust edition
     pub edition: Option<String>,
 
+    /// Whether parsing of headers uses `//@` and errors on malformed headers or
+    /// just allows any comment to have headers and silently ignores things that don't parse
+    /// as a header.
+    pub strict_headers: bool,
+
     // Configuration for various run-make tests frobbing things like C compilers
     // or querying about various LLVM component information.
     pub cc: String,
@@ -420,6 +425,7 @@ impl Default for Config {
             llvm_cxxflags: "llvm-cxxflags".to_string(),
             nodejs: None,
             edition: None,
+            strict_headers: false,
         }
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -435,7 +435,7 @@ fn iter_header(testfile: &Path, cfg: Option<&str>, it: &mut dyn FnMut(&str)) {
         let ln = ln.trim();
         if ln.starts_with("fn") || ln.starts_with("mod") {
             return;
-        } else if let Some(ln) = ln.strip_prefix("//[") {
+        } else if let Some(ln) = ln.strip_prefix("//@[") {
             // A comment like `//[foo]` is specific to revision `foo`
             if let Some((lncfg, ln)) = ln.split_once(']') {
                 if cfg == Some(lncfg) {
@@ -447,7 +447,7 @@ fn iter_header(testfile: &Path, cfg: Option<&str>, it: &mut dyn FnMut(&str)) {
                     ln
                 )
             }
-        } else if let Some(ln) = ln.strip_prefix("//") {
+        } else if let Some(ln) = ln.strip_prefix("//@") {
             it(ln.trim_start());
         }
     }

--- a/src/header.rs
+++ b/src/header.rs
@@ -38,6 +38,7 @@ impl EarlyProps {
 
         iter_header(testfile,
                     None,
+                    config,
                     &mut |ln| {
             props.ignore =
                 props.ignore ||
@@ -300,6 +301,7 @@ impl TestProps {
         let mut has_edition = false;
         iter_header(testfile,
                     cfg,
+                    config,
                     &mut |ln| {
             if let Some(ep) = config.parse_error_pattern(ln) {
                 self.error_patterns.push(ep);
@@ -422,10 +424,16 @@ impl TestProps {
     }
 }
 
-fn iter_header(testfile: &Path, cfg: Option<&str>, it: &mut dyn FnMut(&str)) {
+const HEADER_PREFIXES: [[&str; 2]; 2] = [
+    ["//", "//["],
+    ["//@", "//@["],
+];
+
+fn iter_header(testfile: &Path, cfg: Option<&str>, config: &Config, it: &mut dyn FnMut(&str)) {
     if testfile.is_dir() {
         return;
     }
+    let header_prefix = HEADER_PREFIXES[config.strict_headers as usize];
     let rdr = BufReader::new(File::open(testfile).unwrap());
     for ln in rdr.lines() {
         // Assume that any directives will be found before the first
@@ -435,7 +443,7 @@ fn iter_header(testfile: &Path, cfg: Option<&str>, it: &mut dyn FnMut(&str)) {
         let ln = ln.trim();
         if ln.starts_with("fn") || ln.starts_with("mod") {
             return;
-        } else if let Some(ln) = ln.strip_prefix("//@[") {
+        } else if let Some(ln) = ln.strip_prefix(header_prefix[1]) {
             // A comment like `//[foo]` is specific to revision `foo`
             if let Some((lncfg, ln)) = ln.split_once(']') {
                 if cfg == Some(lncfg) {
@@ -447,7 +455,7 @@ fn iter_header(testfile: &Path, cfg: Option<&str>, it: &mut dyn FnMut(&str)) {
                     ln
                 )
             }
-        } else if let Some(ln) = ln.strip_prefix("//@") {
+        } else if let Some(ln) = ln.strip_prefix(header_prefix[0]) {
             it(ln.trim_start());
         }
     }

--- a/test-project/tests/assembly/panic.rs
+++ b/test-project/tests/assembly/panic.rs
@@ -1,5 +1,5 @@
-// assembly-output: emit-asm
-// compile-flags: --crate-type rlib
+//@assembly-output: emit-asm
+//@compile-flags: --crate-type rlib
 #![no_std]
 
 #[no_mangle]

--- a/test-project/tests/nightly/2018-edition.rs
+++ b/test-project/tests/nightly/2018-edition.rs
@@ -1,5 +1,5 @@
-// edition:2018
-// compile-pass
+//@edition:2018
+//@compile-pass
 
 pub struct Foo;
 impl Foo {

--- a/test-project/tests/nightly/auxiliary/simple_proc_macro.rs
+++ b/test-project/tests/nightly/auxiliary/simple_proc_macro.rs
@@ -1,4 +1,4 @@
-// no-prefer-dynamic
+//@no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
 

--- a/test-project/tests/nightly/some-proc-macro.rs
+++ b/test-project/tests/nightly/some-proc-macro.rs
@@ -1,5 +1,5 @@
-// run-pass
-// aux-build:simple_proc_macro.rs
+//@run-pass
+//@aux-build:simple_proc_macro.rs
 
 #![feature(proc_macro_hygiene)]
 

--- a/test-project/tests/pretty/macro.rs
+++ b/test-project/tests/pretty/macro.rs
@@ -1,6 +1,6 @@
-// pretty-compare-only
-// pretty-mode:expanded
-// pp-exact:macro.pp
+//@pretty-compare-only
+//@pretty-mode:expanded
+//@pp-exact:macro.pp
 
 macro_rules! square {
     ($x:expr) => {

--- a/test-project/tests/run-fail/args-panic.rs
+++ b/test-project/tests/run-fail/args-panic.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-// error-pattern:meep
+//@error-pattern:meep
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/test-project/tests/run-fail/issue-20971.rs
+++ b/test-project/tests/run-fail/issue-20971.rs
@@ -10,7 +10,7 @@
 
 // Regression test for Issue #20971.
 
-// error-pattern:Hello, world!
+//@error-pattern:Hello, world!
 
 pub trait Parser {
     type Input;

--- a/test-project/tests/run-fail/match-wildcards.rs
+++ b/test-project/tests/run-fail/match-wildcards.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:squirrelcupcake
+//@error-pattern:squirrelcupcake
 fn cmp() -> int {
     match (Some('a'), None::<char>) {
         (Some(_), _) => { panic!("squirrelcupcake"); }

--- a/test-project/tests/run-fail/mod-zero.rs
+++ b/test-project/tests/run-fail/mod-zero.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:attempted remainder with a divisor of zero
+//@error-pattern:attempted remainder with a divisor of zero
 fn main() {
     let y = 0;
     let _z = 1 % y;

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -18,6 +18,7 @@ fn run_mode(mode: &'static str, custom_dir: Option<&'static str>) {
             .into(),
     );
     config.clean_rmeta();
+    config.strict_headers = true;
 
     compiletest::run_tests(&config);
 }

--- a/test-project/tests/ui/dyn-keyword.fixed
+++ b/test-project/tests/ui/dyn-keyword.fixed
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// run-rustfix
+//@run-rustfix
 
 #![allow(unused_variables)]
 #![deny(keyword_idents)]

--- a/test-project/tests/ui/dyn-keyword.rs
+++ b/test-project/tests/ui/dyn-keyword.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// run-rustfix
+//@run-rustfix
 
 #![allow(unused_variables)]
 #![deny(keyword_idents)]


### PR DESCRIPTION
This paves the way for actually implementing https://github.com/rust-lang/compiler-team/issues/512 and thus checking that the commands actually parse and aren't silently ignored.

It also is an intermediate step in https://github.com/rust-lang/rust-clippy/pull/10426 for moving to the `ui_test` crate