### PR TITLE
add bpf-linker assembly support

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -1752,6 +1752,10 @@ actual:\n\
                 rustc.arg("--emit=asm");
             }
 
+            Some("bpf-linker") => {
+                rustc.arg("-Clink-args=--emit=asm");
+            }
+
             Some("ptx-linker") => {
                 // No extra flags needed.
             }


### PR DESCRIPTION
Port of https://github.com/rust-lang/rust/pull/110853.
