### PR TITLE
Use a different name for the host/target env vars

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 pub fn main() {
     if env::var("CARGO_FEATURE_RUSTC").is_err() {
-        println!("cargo:rustc-env=TARGET={}", env::var("TARGET").unwrap());
-        println!("cargo:rustc-env=HOST={}", env::var("HOST").unwrap());
+        println!("cargo:rustc-env=COMPILETEST_TARGET={}", env::var("TARGET").unwrap());
+        println!("cargo:rustc-env=COMPILETEST_HOST={}", env::var("HOST").unwrap());
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -393,11 +393,11 @@ impl Default for Config {
             #[cfg(feature = "rustc")]
             target: platform.clone(),
             #[cfg(not(feature = "rustc"))]
-            target: env!("TARGET").to_string(),
+            target: env!("COMPILETEST_TARGET").to_string(),
             #[cfg(feature = "rustc")]
             host: platform.clone(),
             #[cfg(not(feature = "rustc"))]
-            host: env!("HOST").to_string(),
+            host: env!("COMPILETEST_HOST").to_string(),
             rustfix_coverage: false,
             gdb: None,
             gdb_version: None,


### PR DESCRIPTION
I think this should fix using compiletest-rs under sccache (it seems to for us), which I mentioned in https://github.com/Manishearth/compiletest-rs/issues/268#issuecomment-1557545055. It doesn't fix the x.py usage, though, since I'm not sure how that should be fixed, but I'm just going to consider that unrelated.