### PR TITLE
Add Config::clean_rlibs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,11 +24,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
-        override: true
 
     - name: Run tests
       run: cargo test
@@ -48,11 +46,8 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@nightly
       with:
-        profile: minimal
-        toolchain: nightly
-        override: true
         components: rustc-dev, llvm-tools
 
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ let mut config = compiletest::Config::default();
 config.link_deps();
 ```
 
-Note that `link_deps()` should not be used if any of the added paths contain
-spaces, as these are currently not handled correctly.
+Note that `link_deps()` panics if any of the added paths contain spaces, as
+these are currently not handled correctly.
 
 Example
 -------

--- a/src/common.rs
+++ b/src/common.rs
@@ -286,8 +286,10 @@ impl Config {
         // Append to current flags if any are set, otherwise make new String
         let mut flags = self.target_rustcflags.take().unwrap_or_default();
         for p in env::split_paths(&lib_paths) {
+            let p = p.to_str().unwrap();
+            assert!(!p.contains(' '), "spaces in paths not supported: {}", p);
             flags += " -L ";
-            flags += p.to_str().unwrap();
+            flags += p;
         }
 
         self.target_rustcflags = Some(flags);

--- a/src/common.rs
+++ b/src/common.rs
@@ -281,18 +281,13 @@ impl Config {
 
         // Dependencies can be found in the environment variable. Throw everything there into the
         // link flags
-        let lib_paths = env::var(varname).unwrap_or_else(|err| match err {
-            env::VarError::NotPresent => String::new(),
-            err => panic!("can't get {} environment variable: {}", varname, err),
-        });
+        let lib_paths = env::var_os(varname).unwrap_or_default();
 
         // Append to current flags if any are set, otherwise make new String
-        let mut flags = self.target_rustcflags.take().unwrap_or_else(String::new);
-        if !lib_paths.is_empty() {
-            for p in env::split_paths(&lib_paths) {
-                flags += " -L ";
-                flags += p.to_str().unwrap(); // Can't fail. We already know this is unicode
-            }
+        let mut flags = self.target_rustcflags.take().unwrap_or_default();
+        for p in env::split_paths(&lib_paths) {
+            flags += " -L ";
+            flags += p.to_str().unwrap();
         }
 
         self.target_rustcflags = Some(flags);

--- a/src/common.rs
+++ b/src/common.rs
@@ -295,26 +295,61 @@ impl Config {
         self.target_rustcflags = Some(flags);
     }
 
+    fn find_deps_with_extension(&self, ext: &'static str) -> impl Iterator<Item = PathBuf> + '_ {
+        self.target_rustcflags
+            .iter()
+            .flat_map(|flags| flags.split_whitespace().filter(|s| s.ends_with("/deps")))
+            .filter_map(|directory| read_dir(directory).ok())
+            .flat_map(move |entries| {
+                entries.filter_map(Result::ok).filter_map(move |entry| {
+                    let path = entry.path();
+                    let extension = path.extension()?;
+                    (extension == ext).then_some(path)
+                })
+            })
+    }
+
     /// Remove rmeta files from target `deps` directory
     ///
     /// These files are created by `cargo check`, and conflict with
     /// `cargo build` rlib files, causing E0464 for tests which use
     /// the parent crate.
     pub fn clean_rmeta(&self) {
-        if self.target_rustcflags.is_some() {
-            for directory in self.target_rustcflags
-                .as_ref()
-                .unwrap()
-                .split_whitespace()
-                .filter(|s| s.ends_with("/deps"))
-            {
-                if let Ok(mut entries) = read_dir(directory) {
-                    while let Some(Ok(entry)) = entries.next() {
-                        if entry.file_name().to_string_lossy().ends_with(".rmeta") {
-                            let _ = remove_file(entry.path());
+        self.find_deps_with_extension("rmeta").for_each(|path| {
+            let _: Result<(), _> = remove_file(path);
+        })
+    }
+
+    /// Remove "duplicate" rlib files from target `deps` directory
+    ///
+    /// These files are created by `cargo build`; running the tests with
+    /// multiple sets of features can produce multiple rlib files for
+    /// each crate, causing E0464 for tests which use the parent crate.
+    pub fn clean_rlib(&self) {
+        let mut rlibs = self.find_deps_with_extension("rlib").collect::<Vec<_>>();
+        let () = rlibs.sort();
+        let mut rlibs = rlibs.as_slice();
+        loop {
+            match rlibs {
+                [] => break,
+                [first, rest @ ..] => match rest {
+                    [] => break,
+                    [second, ..] => {
+                        fn stem(path: &PathBuf) -> &str {
+                            let stem = (|| {
+                                let file_name = path.file_name()?;
+                                let file_name = file_name.to_str()?;
+                                let (stem, _) = file_name.split_once('-')?;
+                                Some(stem)
+                            })();
+                            stem.unwrap_or_else(|| panic!("unable to parse {}", path.display()))
                         }
+                        if stem(first) == stem(second) {
+                            let _: Result<(), _> = remove_file(first);
+                        }
+                        rlibs = rest;
                     }
-                }
+                },
             }
         }
     }

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -18,6 +18,7 @@ fn run_mode(mode: &'static str, custom_dir: Option<&'static str>) {
             .into(),
     );
     config.clean_rmeta();
+    config.clean_rlib();
     config.strict_headers = true;
 
     compiletest::run_tests(&config);


### PR DESCRIPTION
This new function removes N-1 files matching lib*-*.rlib in the deps
directory, allowing multiple runs of the tests with different features
to successfully link.

Fixes #274.
