### PR TITLE
Fix abbreviation in runtest.rs

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -2879,7 +2879,8 @@ fn read2_abbreviated(mut child: Child) -> io::Result<Output> {
                         return;
                     }
                     let tail = bytes.split_off(new_len - TAIL_LEN).into_boxed_slice();
-                    let head = replace(bytes, Vec::new());
+                    let mut head = replace(bytes, Vec::new());
+                    head.truncate(HEAD_LEN);
                     let skipped = new_len - HEAD_LEN - TAIL_LEN;
                     ProcOutput::Abbreviated { head, skipped, tail }
                 }


### PR DESCRIPTION
In this commit, `head` will be truncated at `HEAD_LEN`, rather than left with `new_len - TAIL_LEN` bytes.

I happened to use this library in a project I am participating and found that the `.stdout` generated by `cargo bless` frequently changed when the command is executed, while the bytes skipped (`<<<<<< SKIPPED * BYTES >>>>>>`) was a constant value.

That is actually because the `read2_abbreviated` function is not working properly: in the `extend` function implemented for `ProcOutput`, when the output exceeds `HEAD_LEN + TAIL_LEN`, it splits off the last `TAIL_LEN` bytes for `tail`, and the rest for `head`. In this way, the first `new_len - TAIL_LEN` bytes are left in `head`, but `HEAD_LEN + TAIL_LEN > new_len` holds (otherwise the extend function will return early), i.e. the length of `head` is currently dependent on `new_len`, rather than the fixed value `HEAD_LEN`.

The fix is also simple: just truncate `head` at `HEAD_LEN`.