### PR TITLE
Add optional preprocessing before FileCheck

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,13 @@ use std::env;
 
 pub fn main() {
     if env::var("CARGO_FEATURE_RUSTC").is_err() {
-        println!("cargo:rustc-env=COMPILETEST_TARGET={}", env::var("TARGET").unwrap());
-        println!("cargo:rustc-env=COMPILETEST_HOST={}", env::var("HOST").unwrap());
+        println!(
+            "cargo:rustc-env=COMPILETEST_TARGET={}",
+            env::var("TARGET").unwrap()
+        );
+        println!(
+            "cargo:rustc-env=COMPILETEST_HOST={}",
+            env::var("HOST").unwrap()
+        );
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,6 +12,7 @@ pub use self::Mode::*;
 use std::env;
 use std::fmt;
 use std::fs::{read_dir, remove_file};
+use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -125,6 +126,9 @@ pub struct Config {
 
     /// The python executable to use for htmldocck
     pub docck_python: String,
+
+    /// A function to run before FileCheck.
+    pub llvm_filecheck_preprocess: Option<fn(&Path, &Path)>,
 
     /// The llvm FileCheck binary path
     pub llvm_filecheck: Option<PathBuf>,
@@ -409,6 +413,7 @@ impl Default for Config {
             docck_python: "docck-python".to_owned(),
             valgrind_path: None,
             force_valgrind: false,
+            llvm_filecheck_preprocess: None,
             llvm_filecheck: None,
             src_base: PathBuf::from("tests/run-pass"),
             build_base: env::temp_dir(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,11 +12,11 @@ pub use self::Mode::*;
 use std::env;
 use std::fmt;
 use std::fs::{read_dir, remove_file};
-use std::str::FromStr;
 use std::path::PathBuf;
+use std::str::FromStr;
 
-use test::ColorConfig;
 use runtest::dylib_env_var;
+use test::ColorConfig;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Mode {
@@ -79,25 +79,27 @@ impl FromStr for Mode {
 
 impl fmt::Display for Mode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(match *self {
-                              CompileFail => "compile-fail",
-                              ParseFail => "parse-fail",
-                              RunFail => "run-fail",
-                              RunPass => "run-pass",
-                              RunPassValgrind => "run-pass-valgrind",
-                              Pretty => "pretty",
-                              DebugInfoGdb => "debuginfo-gdb",
-                              DebugInfoLldb => "debuginfo-lldb",
-                              Codegen => "codegen",
-                              Rustdoc => "rustdoc",
-                              CodegenUnits => "codegen-units",
-                              Incremental => "incremental",
-                              RunMake => "run-make",
-                              Ui => "ui",
-                              MirOpt => "mir-opt",
-                              Assembly => "assembly",
-                          },
-                          f)
+        fmt::Display::fmt(
+            match *self {
+                CompileFail => "compile-fail",
+                ParseFail => "parse-fail",
+                RunFail => "run-fail",
+                RunPass => "run-pass",
+                RunPassValgrind => "run-pass-valgrind",
+                Pretty => "pretty",
+                DebugInfoGdb => "debuginfo-gdb",
+                DebugInfoLldb => "debuginfo-lldb",
+                Codegen => "codegen",
+                Rustdoc => "rustdoc",
+                CodegenUnits => "codegen-units",
+                Incremental => "incremental",
+                RunMake => "run-make",
+                Ui => "ui",
+                MirOpt => "mir-opt",
+                Assembly => "assembly",
+            },
+            f,
+        )
     }
 }
 
@@ -252,11 +254,7 @@ pub struct TestPaths {
 }
 
 /// Used by `ui` tests to generate things like `foo.stderr` from `foo.rs`.
-pub fn expected_output_path(
-    testpaths: &TestPaths,
-    revision: Option<&str>,
-    kind: &str,
-) -> PathBuf {
+pub fn expected_output_path(testpaths: &TestPaths, revision: Option<&str>, kind: &str) -> PathBuf {
     assert!(UI_EXTENSIONS.contains(&kind));
     let mut parts = Vec::new();
 
@@ -356,7 +354,9 @@ impl Config {
 
     #[cfg(feature = "tmp")]
     pub fn tempdir(mut self) -> ConfigWithTemp {
-        let tmp = tempfile::Builder::new().prefix("compiletest").tempdir()
+        let tmp = tempfile::Builder::new()
+            .prefix("compiletest")
+            .tempdir()
             .expect("failed to create temporary directory");
         self.build_base = tmp.path().to_owned();
         config_tempdir::ConfigWithTemp {
@@ -368,8 +368,8 @@ impl Config {
 
 #[cfg(feature = "tmp")]
 mod config_tempdir {
-    use tempfile;
     use std::ops;
+    use tempfile;
 
     pub struct ConfigWithTemp {
         pub config: super::Config,
@@ -393,7 +393,6 @@ mod config_tempdir {
 
 #[cfg(feature = "tmp")]
 pub use self::config_tempdir::ConfigWithTemp;
-
 
 impl Default for Config {
     fn default() -> Config {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,8 +11,8 @@ use self::WhichLine::*;
 
 use std::fmt;
 use std::fs::File;
-use std::io::BufReader;
 use std::io::prelude::*;
+use std::io::BufReader;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -35,8 +35,7 @@ impl FromStr for ErrorKind {
             "ERROR" => Ok(ErrorKind::Error),
             "NOTE" => Ok(ErrorKind::Note),
             "SUGGESTION" => Ok(ErrorKind::Suggestion),
-            "WARN" |
-            "WARNING" => Ok(ErrorKind::Warning),
+            "WARN" | "WARNING" => Ok(ErrorKind::Warning),
             _ => Err(()),
         }
     }
@@ -101,23 +100,25 @@ pub fn load_errors(testfile: &Path, cfg: Option<&str>) -> Vec<Error> {
     rdr.lines()
         .enumerate()
         .filter_map(|(line_num, line)| {
-            parse_expected(last_nonfollow_error, line_num + 1, &line.unwrap(), &tag)
-                .map(|(which, error)| {
+            parse_expected(last_nonfollow_error, line_num + 1, &line.unwrap(), &tag).map(
+                |(which, error)| {
                     match which {
                         FollowPrevious(_) => {}
                         _ => last_nonfollow_error = Some(error.line_num),
                     }
                     error
-                })
+                },
+            )
         })
         .collect()
 }
 
-fn parse_expected(last_nonfollow_error: Option<usize>,
-                  line_num: usize,
-                  line: &str,
-                  tag: &str)
-                  -> Option<(WhichLine, Error)> {
+fn parse_expected(
+    last_nonfollow_error: Option<usize>,
+    line_num: usize,
+    line: &str,
+    tag: &str,
+) -> Option<(WhichLine, Error)> {
     let start = match line.find(tag) {
         Some(i) => i,
         None => return None,
@@ -125,7 +126,13 @@ fn parse_expected(last_nonfollow_error: Option<usize>,
     let (follow, adjusts) = if line[start + tag.len()..].chars().next().unwrap() == '|' {
         (true, 0)
     } else {
-        (false, line[start + tag.len()..].chars().take_while(|c| *c == '^').count())
+        (
+            false,
+            line[start + tag.len()..]
+                .chars()
+                .take_while(|c| *c == '^')
+                .count(),
+        )
     };
     let kind_start = start + tag.len() + adjusts + (follow as usize);
     let (kind, msg);
@@ -133,12 +140,14 @@ fn parse_expected(last_nonfollow_error: Option<usize>,
         .split_whitespace()
         .next()
         .expect("Encountered unexpected empty comment")
-        .parse::<ErrorKind>() {
+        .parse::<ErrorKind>()
+    {
         Ok(k) => {
             // If we find `//~ ERROR foo` or something like that:
             kind = Some(k);
             let letters = line[kind_start..].chars();
-            msg = letters.skip_while(|c| c.is_whitespace())
+            msg = letters
+                .skip_while(|c| c.is_whitespace())
                 .skip_while(|c| !c.is_whitespace())
                 .collect::<String>();
         }
@@ -146,7 +155,8 @@ fn parse_expected(last_nonfollow_error: Option<usize>,
             // Otherwise we found `//~ foo`:
             kind = None;
             let letters = line[kind_start..].chars();
-            msg = letters.skip_while(|c| c.is_whitespace())
+            msg = letters
+                .skip_while(|c| c.is_whitespace())
                 .collect::<String>();
         }
     }
@@ -154,8 +164,10 @@ fn parse_expected(last_nonfollow_error: Option<usize>,
 
     let (which, line_num) = if follow {
         assert_eq!(adjusts, 0, "use either //~| or //~^, not both.");
-        let line_num = last_nonfollow_error.expect("encountered //~| without \
-                                                    preceding //~^ line.");
+        let line_num = last_nonfollow_error.expect(
+            "encountered //~| without \
+                                                    preceding //~^ line.",
+        );
         (FollowPrevious(line_num), line_num)
     } else {
         let which = if adjusts > 0 {
@@ -167,16 +179,16 @@ fn parse_expected(last_nonfollow_error: Option<usize>,
         (which, line_num)
     };
 
-    debug!("line={} tag={:?} which={:?} kind={:?} msg={:?}",
-           line_num,
-           tag,
-           which,
-           kind,
-           msg);
-    Some((which,
-          Error {
-        line_num,
-        kind,
-        msg,
-    }))
+    debug!(
+        "line={} tag={:?} which={:?} kind={:?} msg={:?}",
+        line_num, tag, which, kind, msg
+    );
+    Some((
+        which,
+        Error {
+            line_num,
+            kind,
+            msg,
+        },
+    ))
 }

--- a/src/read2.rs
+++ b/src/read2.rs
@@ -16,11 +16,13 @@ pub use self::imp::read2;
 #[cfg(not(any(unix, windows)))]
 mod imp {
     use std::io::{self, Read};
-    use std::process::{ChildStdout, ChildStderr};
+    use std::process::{ChildStderr, ChildStdout};
 
-    pub fn read2(out_pipe: ChildStdout,
-                 err_pipe: ChildStderr,
-                 data: &mut FnMut(bool, &mut Vec<u8>, bool)) -> io::Result<()> {
+    pub fn read2(
+        out_pipe: ChildStdout,
+        err_pipe: ChildStderr,
+        data: &mut FnMut(bool, &mut Vec<u8>, bool),
+    ) -> io::Result<()> {
         let mut buffer = Vec::new();
         out_pipe.read_to_end(&mut buffer)?;
         data(true, &mut buffer, true);
@@ -33,16 +35,18 @@ mod imp {
 
 #[cfg(unix)]
 mod imp {
-    use std::io::prelude::*;
+    use libc;
     use std::io;
+    use std::io::prelude::*;
     use std::mem;
     use std::os::unix::prelude::*;
-    use std::process::{ChildStdout, ChildStderr};
-    use libc;
+    use std::process::{ChildStderr, ChildStdout};
 
-    pub fn read2(mut out_pipe: ChildStdout,
-                 mut err_pipe: ChildStderr,
-                 data: &mut dyn FnMut(bool, &mut Vec<u8>, bool)) -> io::Result<()> {
+    pub fn read2(
+        mut out_pipe: ChildStdout,
+        mut err_pipe: ChildStderr,
+        data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
+    ) -> io::Result<()> {
         unsafe {
             libc::fcntl(out_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
             libc::fcntl(err_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
@@ -64,9 +68,9 @@ mod imp {
             if r == -1 {
                 let err = io::Error::last_os_error();
                 if err.kind() == io::ErrorKind::Interrupted {
-                    continue
+                    continue;
                 }
-                return Err(err)
+                return Err(err);
             }
 
             // Read as much as we can from each pipe, ignoring EWOULDBLOCK or
@@ -74,15 +78,13 @@ mod imp {
             // reader will return Ok(0), in which case we'll see `Ok` ourselves. In
             // this case we flip the other fd back into blocking mode and read
             // whatever's leftover on that file descriptor.
-            let handle = |res: io::Result<_>| {
-                match res {
-                    Ok(_) => Ok(true),
-                    Err(e) => {
-                        if e.kind() == io::ErrorKind::WouldBlock {
-                            Ok(false)
-                        } else {
-                            Err(e)
-                        }
+            let handle = |res: io::Result<_>| match res {
+                Ok(_) => Ok(true),
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::WouldBlock {
+                        Ok(false)
+                    } else {
+                        Err(e)
                     }
                 }
             };
@@ -96,7 +98,7 @@ mod imp {
             data(false, &mut err, err_done);
 
             if out_done && err_done {
-                return Ok(())
+                return Ok(());
             }
         }
     }
@@ -109,7 +111,7 @@ mod imp {
 
     use std::io;
     use std::os::windows::prelude::*;
-    use std::process::{ChildStdout, ChildStderr};
+    use std::process::{ChildStderr, ChildStdout};
     use std::slice;
 
     use self::miow::iocp::{CompletionPort, CompletionStatus};
@@ -124,9 +126,11 @@ mod imp {
         done: bool,
     }
 
-    pub fn read2(out_pipe: ChildStdout,
-                 err_pipe: ChildStderr,
-                 data: &mut FnMut(bool, &mut Vec<u8>, bool)) -> io::Result<()> {
+    pub fn read2(
+        out_pipe: ChildStdout,
+        err_pipe: ChildStderr,
+        data: &mut FnMut(bool, &mut Vec<u8>, bool),
+    ) -> io::Result<()> {
         let mut out = Vec::new();
         let mut err = Vec::new();
 
@@ -202,7 +206,9 @@ mod imp {
         if v.capacity() == v.len() {
             v.reserve(1);
         }
-        slice::from_raw_parts_mut(v.as_mut_ptr().offset(v.len() as isize),
-                                  v.capacity() - v.len())
+        slice::from_raw_parts_mut(
+            v.as_mut_ptr().offset(v.len() as isize),
+            v.capacity() - v.len(),
+        )
     }
 }

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -8,30 +8,30 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use common::{Config, TestPaths};
+use crate::util::{logv, PathBufExt};
 use common::{expected_output_path, UI_FIXED, UI_STDERR, UI_STDOUT};
+use common::{Assembly, Incremental, MirOpt, RunMake, Ui};
+use common::{Codegen, CodegenUnits, DebugInfoGdb, DebugInfoLldb, Rustdoc};
 use common::{CompileFail, ParseFail, Pretty, RunFail, RunPass, RunPassValgrind};
-use common::{Codegen, DebugInfoLldb, DebugInfoGdb, Rustdoc, CodegenUnits};
-use common::{Incremental, RunMake, Ui, MirOpt, Assembly};
+use common::{Config, TestPaths};
 use diff;
-use errors::{self, ErrorKind, Error};
+use errors::{self, Error, ErrorKind};
 use filetime::FileTime;
+use header::TestProps;
 use json;
 use regex::Regex;
 use rustfix::{apply_suggestions, get_suggestions_from_json, Filter};
-use header::TestProps;
-use crate::util::{logv, PathBufExt};
 
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::env;
 use std::ffi::OsString;
-use std::fs::{self, File, create_dir_all, OpenOptions};
 use std::fmt;
+use std::fs::{self, create_dir_all, File, OpenOptions};
 use std::io::prelude::*;
 use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output, ExitStatus, Stdio, Child};
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::str;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -70,7 +70,6 @@ pub fn dylib_env_var() -> &'static str {
 
 pub fn run(config: Config, testpaths: &TestPaths) {
     match &*config.target {
-
         "arm-linux-androideabi" | "armv7-linux-androideabi" | "aarch64-linux-android" => {
             if !config.adb_device_status {
                 panic!("android device not available");
@@ -92,24 +91,24 @@ pub fn run(config: Config, testpaths: &TestPaths) {
     debug!("running {:?}", testpaths.file.display());
     let base_props = TestProps::from_file(&testpaths.file, None, &config);
 
-    let base_cx = TestCx { config: &config,
-                           props: &base_props,
-                           testpaths,
-                           revision: None };
+    let base_cx = TestCx {
+        config: &config,
+        props: &base_props,
+        testpaths,
+        revision: None,
+    };
     base_cx.init_all();
 
     if base_props.revisions.is_empty() {
         base_cx.run_revision()
     } else {
         for revision in &base_props.revisions {
-            let revision_props = TestProps::from_file(&testpaths.file,
-                                                      Some(revision),
-                                                      &config);
+            let revision_props = TestProps::from_file(&testpaths.file, Some(revision), &config);
             let rev_cx = TestCx {
                 config: &config,
                 props: &revision_props,
                 testpaths,
-                revision: Some(revision)
+                revision: Some(revision),
             };
             rev_cx.run_revision();
         }
@@ -124,7 +123,7 @@ struct TestCx<'test> {
     config: &'test Config,
     props: &'test TestProps,
     testpaths: &'test TestPaths,
-    revision: Option<&'test str>
+    revision: Option<&'test str>,
 }
 
 struct DebuggerCommands {
@@ -146,8 +145,7 @@ impl<'test> TestCx<'test> {
     /// revisions, exactly once, with revision == None).
     fn run_revision(&self) {
         match self.config.mode {
-            CompileFail |
-            ParseFail => self.run_cfail_test(),
+            CompileFail | ParseFail => self.run_cfail_test(),
             RunFail => self.run_rfail_test(),
             RunPass => self.run_rpass_test(),
             RunPassValgrind => self.run_valgrind_test(),
@@ -175,15 +173,14 @@ impl<'test> TestCx<'test> {
 
         if self.props.must_compile_successfully {
             if !proc_res.status.success() {
-                self.fatal_proc_rec(
-                    "test compilation failed although it shouldn't!",
-                    &proc_res);
+                self.fatal_proc_rec("test compilation failed although it shouldn't!", &proc_res);
             }
         } else {
             if proc_res.status.success() {
                 self.fatal_proc_rec(
                     &format!("{} test compiled successfully!", self.config.mode)[..],
-                    &proc_res);
+                    &proc_res,
+                );
             }
 
             self.check_correct_failure_status(&proc_res);
@@ -237,9 +234,9 @@ impl<'test> TestCx<'test> {
         const RUST_ERR: i32 = 1;
         if proc_res.status.code() != Some(RUST_ERR) {
             self.fatal_proc_rec(
-                &format!("failure produced the wrong error: {}",
-                         proc_res.status),
-                proc_res);
+                &format!("failure produced the wrong error: {}", proc_res.status),
+                proc_res,
+            );
         }
     }
 
@@ -252,8 +249,10 @@ impl<'test> TestCx<'test> {
 
         // FIXME(#41968): Move this check to tidy?
         let expected_errors = errors::load_errors(&self.testpaths.file, self.revision);
-        assert!(expected_errors.is_empty(),
-                "run-pass tests with expected warnings should be moved to ui/");
+        assert!(
+            expected_errors.is_empty(),
+            "run-pass tests with expected warnings should be moved to ui/"
+        );
 
         let proc_res = self.exec_compiled_test();
 
@@ -278,7 +277,10 @@ impl<'test> TestCx<'test> {
 
         let mut new_config = self.config.clone();
         new_config.runtool = new_config.valgrind_path.clone();
-        let new_cx = TestCx { config: &new_config, ..*self };
+        let new_cx = TestCx {
+            config: &new_config,
+            ..*self
+        };
         proc_res = new_cx.exec_compiled_test();
 
         if !proc_res.status.success() {
@@ -290,28 +292,46 @@ impl<'test> TestCx<'test> {
         if self.props.pp_exact.is_some() {
             logv(self.config, "testing for exact pretty-printing".to_owned());
         } else {
-            logv(self.config, "testing for converging pretty-printing".to_owned());
+            logv(
+                self.config,
+                "testing for converging pretty-printing".to_owned(),
+            );
         }
 
-        let rounds = match self.props.pp_exact { Some(_) => 1, None => 2 };
+        let rounds = match self.props.pp_exact {
+            Some(_) => 1,
+            None => 2,
+        };
 
         let mut src = String::new();
-        File::open(&self.testpaths.file).unwrap().read_to_string(&mut src).unwrap();
+        File::open(&self.testpaths.file)
+            .unwrap()
+            .read_to_string(&mut src)
+            .unwrap();
         let mut srcs = vec![src];
 
         let mut round = 0;
         while round < rounds {
-            logv(self.config, format!("pretty-printing round {} revision {:?}",
-                                      round, self.revision));
+            logv(
+                self.config,
+                format!(
+                    "pretty-printing round {} revision {:?}",
+                    round, self.revision
+                ),
+            );
             let proc_res = self.print_source(srcs[round].to_owned(), &self.props.pretty_mode);
 
             if !proc_res.status.success() {
-                self.fatal_proc_rec(&format!("pretty-printing failed in round {} revision {:?}",
-                                             round, self.revision),
-                                    &proc_res);
+                self.fatal_proc_rec(
+                    &format!(
+                        "pretty-printing failed in round {} revision {:?}",
+                        round, self.revision
+                    ),
+                    &proc_res,
+                );
             }
 
-            let ProcRes{ stdout, .. } = proc_res;
+            let ProcRes { stdout, .. } = proc_res;
             srcs.push(stdout);
             round += 1;
         }
@@ -320,10 +340,13 @@ impl<'test> TestCx<'test> {
             Some(ref file) => {
                 let filepath = self.testpaths.file.parent().unwrap().join(file);
                 let mut s = String::new();
-                File::open(&filepath).unwrap().read_to_string(&mut s).unwrap();
+                File::open(&filepath)
+                    .unwrap()
+                    .read_to_string(&mut s)
+                    .unwrap();
                 s
             }
-            None => { srcs[srcs.len() - 2].clone() }
+            None => srcs[srcs.len() - 2].clone(),
         };
         let mut actual = srcs[srcs.len() - 1].clone();
 
@@ -337,7 +360,9 @@ impl<'test> TestCx<'test> {
         self.compare_source(&expected, &actual);
 
         // If we're only making sure that the output matches then just stop here
-        if self.props.pretty_compare_only { return; }
+        if self.props.pretty_compare_only {
+            return;
+        }
 
         // Finally, let's make sure it actually appears to remain valid code
         let proc_res = self.typecheck_source(actual);
@@ -345,7 +370,9 @@ impl<'test> TestCx<'test> {
             self.fatal_proc_rec("pretty-printed source does not typecheck", &proc_res);
         }
 
-        if !self.props.pretty_expanded { return }
+        if !self.props.pretty_expanded {
+            return;
+        }
 
         // additionally, run `--pretty expanded` and try to build it.
         let proc_res = self.print_source(srcs[round].clone(), "expanded");
@@ -353,12 +380,16 @@ impl<'test> TestCx<'test> {
             self.fatal_proc_rec("pretty-printing (expanded) failed", &proc_res);
         }
 
-        let ProcRes{ stdout: expanded_src, .. } = proc_res;
+        let ProcRes {
+            stdout: expanded_src,
+            ..
+        } = proc_res;
         let proc_res = self.typecheck_source(expanded_src);
         if !proc_res.status.success() {
             self.fatal_proc_rec(
                 "pretty-printed source (expanded) does not typecheck",
-                &proc_res);
+                &proc_res,
+            );
         }
     }
 
@@ -366,26 +397,29 @@ impl<'test> TestCx<'test> {
         let aux_dir = self.aux_output_dir_name();
 
         let mut rustc = Command::new(&self.config.rustc_path);
-        rustc.arg("-")
+        rustc
+            .arg("-")
             .args(&["-Z", &format!("unpretty={}", pretty_type)])
             .args(&["--target", &self.config.target])
-            .arg("-L").arg(&aux_dir)
+            .arg("-L")
+            .arg(&aux_dir)
             .args(self.split_maybe_args(&self.config.target_rustcflags))
             .args(&self.props.compile_flags)
             .envs(self.props.exec_env.clone());
 
-        self.compose_and_run(rustc,
-                             self.config.compile_lib_path.to_str().unwrap(),
-                             Some(aux_dir.to_str().unwrap()),
-                             Some(src))
+        self.compose_and_run(
+            rustc,
+            self.config.compile_lib_path.to_str().unwrap(),
+            Some(aux_dir.to_str().unwrap()),
+            Some(src),
+        )
     }
 
-    fn compare_source(&self,
-                      expected: &str,
-                      actual: &str) {
+    fn compare_source(&self, expected: &str, actual: &str) {
         if expected != actual {
             self.error("pretty-printed source does not match expected source");
-            println!("\n\
+            println!(
+                "\n\
 expected:\n\
 ------------------------------------------\n\
 {}\n\
@@ -395,7 +429,8 @@ actual:\n\
 {}\n\
 ------------------------------------------\n\
 \n",
-                     expected, actual);
+                expected, actual
+            );
             panic!();
         }
     }
@@ -415,12 +450,16 @@ actual:\n\
 
         let aux_dir = self.aux_output_dir_name();
 
-        rustc.arg("-")
+        rustc
+            .arg("-")
             .arg("-Zno-trans")
-            .arg("--out-dir").arg(&out_dir)
+            .arg("--out-dir")
+            .arg(&out_dir)
             .arg(&format!("--target={}", target))
-            .arg("-L").arg(&self.config.build_base)
-            .arg("-L").arg(aux_dir);
+            .arg("-L")
+            .arg(&self.config.build_base)
+            .arg("-L")
+            .arg(aux_dir);
 
         if let Some(revision) = self.revision {
             rustc.args(&["--cfg", revision]);
@@ -438,7 +477,7 @@ actual:\n\
         let config = Config {
             target_rustcflags: self.cleanup_debug_info_options(&self.config.target_rustcflags),
             host_rustcflags: self.cleanup_debug_info_options(&self.config.host_rustcflags),
-            .. self.config.clone()
+            ..self.config.clone()
         };
 
         let test_cx = TestCx {
@@ -465,7 +504,7 @@ actual:\n\
         let DebuggerCommands {
             commands,
             check_lines,
-            breakpoint_lines
+            breakpoint_lines,
         } = self.parse_debugger_commands(prefixes);
         let mut cmds = commands.join("\n");
 
@@ -479,15 +518,12 @@ actual:\n\
 
         let debugger_run_result;
         match &*self.config.target {
-            "arm-linux-androideabi" |
-            "armv7-linux-androideabi" |
-            "aarch64-linux-android" => {
-
+            "arm-linux-androideabi" | "armv7-linux-androideabi" | "aarch64-linux-android" => {
                 cmds = cmds.replace("run", "continue");
 
                 let tool_path = match self.config.android_cross_path.to_str() {
                     Some(x) => x.to_owned(),
-                    None => self.fatal("cannot find android cross path")
+                    None => self.fatal("cannot find android cross path"),
                 };
 
                 // write debugger script
@@ -496,15 +532,19 @@ actual:\n\
                 script_str.push_str(&format!("set sysroot {}\n", tool_path));
                 script_str.push_str(&format!("file {}\n", exe_file.to_str().unwrap()));
                 script_str.push_str("target remote :5039\n");
-                script_str.push_str(&format!("set solib-search-path \
+                script_str.push_str(&format!(
+                    "set solib-search-path \
                                               ./{}/stage2/lib/rustlib/{}/lib/\n",
-                                             self.config.host, self.config.target));
+                    self.config.host, self.config.target
+                ));
                 for line in &breakpoint_lines {
-                    script_str.push_str(&format!("break {:?}:{}\n",
-                                                 self.testpaths.file.file_name()
-                                                 .unwrap()
-                                                 .to_string_lossy(),
-                                                 *line)[..]);
+                    script_str.push_str(
+                        &format!(
+                            "break {:?}:{}\n",
+                            self.testpaths.file.file_name().unwrap().to_string_lossy(),
+                            *line
+                        )[..],
+                    );
                 }
                 script_str.push_str(&cmds);
                 script_str.push_str("\nquit\n");
@@ -526,14 +566,18 @@ actual:\n\
                     .status()
                     .expect(&format!("failed to exec `{:?}`", adb_path));
 
-                let adb_arg = format!("export LD_LIBRARY_PATH={}; \
+                let adb_arg = format!(
+                    "export LD_LIBRARY_PATH={}; \
                                        gdbserver{} :5039 {}/{}",
-                                      self.config.adb_test_dir.clone(),
-                                      if self.config.target.contains("aarch64")
-                                      {"64"} else {""},
-                                      self.config.adb_test_dir.clone(),
-                                      exe_file.file_name().unwrap().to_str()
-                                      .unwrap());
+                    self.config.adb_test_dir.clone(),
+                    if self.config.target.contains("aarch64") {
+                        "64"
+                    } else {
+                        ""
+                    },
+                    self.config.adb_test_dir.clone(),
+                    exe_file.file_name().unwrap().to_str().unwrap()
+                );
 
                 debug!("adb arg: {}", adb_arg);
                 let mut adb = Command::new(adb_path)
@@ -552,25 +596,26 @@ actual:\n\
                     line.truncate(0);
                     stdout.read_line(&mut line).unwrap();
                     if line.starts_with("Listening on port 5039") {
-                        break
+                        break;
                     }
                 }
                 drop(stdout);
 
                 let debugger_script = self.make_out_name("debugger.script");
                 // FIXME (#9639): This needs to handle non-utf8 paths
-                let debugger_opts =
-                    vec!["-quiet".to_owned(),
-                         "-batch".to_owned(),
-                         "-nx".to_owned(),
-                         format!("-command={}", debugger_script.to_str().unwrap())];
+                let debugger_opts = vec![
+                    "-quiet".to_owned(),
+                    "-batch".to_owned(),
+                    "-nx".to_owned(),
+                    format!("-command={}", debugger_script.to_str().unwrap()),
+                ];
 
                 let mut gdb_path = tool_path;
                 gdb_path.push_str("/bin/gdb");
                 let Output {
                     status,
                     stdout,
-                    stderr
+                    stderr,
                 } = Command::new(&gdb_path)
                     .args(&debugger_opts)
                     .output()
@@ -595,14 +640,16 @@ actual:\n\
             }
 
             _ => {
-                let rust_src_root = self.config.find_rust_src_root().expect(
-                    "Could not find Rust source root",
-                );
+                let rust_src_root = self
+                    .config
+                    .find_rust_src_root()
+                    .expect("Could not find Rust source root");
                 let rust_pp_module_rel_path = Path::new("./src/etc");
-                let rust_pp_module_abs_path = rust_src_root.join(rust_pp_module_rel_path)
-                                                           .to_str()
-                                                           .unwrap()
-                                                           .to_owned();
+                let rust_pp_module_abs_path = rust_src_root
+                    .join(rust_pp_module_rel_path)
+                    .to_str()
+                    .unwrap()
+                    .to_owned();
                 // write debugger script
                 let mut script_str = String::with_capacity(2048);
                 script_str.push_str(&format!("set charset {}\n", Self::charset()));
@@ -610,21 +657,25 @@ actual:\n\
 
                 match self.config.gdb_version {
                     Some(version) => {
-                        println!("NOTE: compiletest thinks it is using GDB version {}",
-                                 version);
+                        println!(
+                            "NOTE: compiletest thinks it is using GDB version {}",
+                            version
+                        );
 
                         if version > extract_gdb_version("7.4").unwrap() {
                             // Add the directory containing the pretty printers to
                             // GDB's script auto loading safe path
-                            script_str.push_str(
-                                &format!("add-auto-load-safe-path {}\n",
-                                         rust_pp_module_abs_path.replace(r"\", r"\\"))
-                            );
+                            script_str.push_str(&format!(
+                                "add-auto-load-safe-path {}\n",
+                                rust_pp_module_abs_path.replace(r"\", r"\\")
+                            ));
                         }
                     }
                     _ => {
-                        println!("NOTE: compiletest does not know which version of \
-                                  GDB it is using");
+                        println!(
+                            "NOTE: compiletest does not know which version of \
+                                  GDB it is using"
+                        );
                     }
                 }
 
@@ -633,13 +684,13 @@ actual:\n\
                 script_str.push_str("set print pretty off\n");
 
                 // Add the pretty printer directory to GDB's source-file search path
-                script_str.push_str(&format!("directory {}\n",
-                                             rust_pp_module_abs_path));
+                script_str.push_str(&format!("directory {}\n", rust_pp_module_abs_path));
 
                 // Load the target executable
-                script_str.push_str(&format!("file {}\n",
-                                             exe_file.to_str().unwrap()
-                                             .replace(r"\", r"\\")));
+                script_str.push_str(&format!(
+                    "file {}\n",
+                    exe_file.to_str().unwrap().replace(r"\", r"\\")
+                ));
 
                 // Force GDB to print values in the Rust format.
                 if self.config.gdb_native_rust {
@@ -648,10 +699,11 @@ actual:\n\
 
                 // Add line breakpoints
                 for line in &breakpoint_lines {
-                    script_str.push_str(&format!("break '{}':{}\n",
-                                                 self.testpaths.file.file_name().unwrap()
-                                                 .to_string_lossy(),
-                                                 *line));
+                    script_str.push_str(&format!(
+                        "break '{}':{}\n",
+                        self.testpaths.file.file_name().unwrap().to_string_lossy(),
+                        *line
+                    ));
                 }
 
                 script_str.push_str(&cmds);
@@ -663,21 +715,23 @@ actual:\n\
                 let debugger_script = self.make_out_name("debugger.script");
 
                 // FIXME (#9639): This needs to handle non-utf8 paths
-                let debugger_opts =
-                    vec!["-quiet".to_owned(),
-                         "-batch".to_owned(),
-                         "-nx".to_owned(),
-                         format!("-command={}", debugger_script.to_str().unwrap())];
+                let debugger_opts = vec![
+                    "-quiet".to_owned(),
+                    "-batch".to_owned(),
+                    "-nx".to_owned(),
+                    format!("-command={}", debugger_script.to_str().unwrap()),
+                ];
 
                 let mut gdb = Command::new(self.config.gdb.as_ref().unwrap());
                 gdb.args(&debugger_opts)
                     .env("PYTHONPATH", rust_pp_module_abs_path);
 
-                debugger_run_result =
-                    self.compose_and_run(gdb,
-                                         self.config.run_lib_path.to_str().unwrap(),
-                                         None,
-                                         None);
+                debugger_run_result = self.compose_and_run(
+                    gdb,
+                    self.config.run_lib_path.to_str().unwrap(),
+                    None,
+                    None,
+                );
             }
         }
 
@@ -698,9 +752,8 @@ actual:\n\
         let config = Config {
             target_rustcflags: self.cleanup_debug_info_options(&self.config.target_rustcflags),
             host_rustcflags: self.cleanup_debug_info_options(&self.config.host_rustcflags),
-            .. self.config.clone()
+            ..self.config.clone()
         };
-
 
         let test_cx = TestCx {
             config: &config,
@@ -721,12 +774,16 @@ actual:\n\
 
         match self.config.lldb_version {
             Some(ref version) => {
-                println!("NOTE: compiletest thinks it is using LLDB version {}",
-                         version);
+                println!(
+                    "NOTE: compiletest thinks it is using LLDB version {}",
+                    version
+                );
             }
             _ => {
-                println!("NOTE: compiletest does not know which version of \
-                          LLDB it is using");
+                println!(
+                    "NOTE: compiletest does not know which version of \
+                          LLDB it is using"
+                );
             }
         }
 
@@ -746,17 +803,19 @@ actual:\n\
         script_str.push_str("version\n");
 
         // Switch LLDB into "Rust mode"
-        let rust_src_root = self.config.find_rust_src_root().expect(
-            "Could not find Rust source root",
-        );
+        let rust_src_root = self
+            .config
+            .find_rust_src_root()
+            .expect("Could not find Rust source root");
         let rust_pp_module_rel_path = Path::new("./src/etc/lldb_rust_formatters.py");
-        let rust_pp_module_abs_path = rust_src_root.join(rust_pp_module_rel_path)
-                                                   .to_str()
-                                                   .unwrap()
-                                                   .to_owned();
+        let rust_pp_module_abs_path = rust_src_root
+            .join(rust_pp_module_rel_path)
+            .to_str()
+            .unwrap()
+            .to_owned();
 
-        script_str.push_str(&format!("command script import {}\n",
-                                     &rust_pp_module_abs_path[..])[..]);
+        script_str
+            .push_str(&format!("command script import {}\n", &rust_pp_module_abs_path[..])[..]);
         script_str.push_str("type summary add --no-value ");
         script_str.push_str("--python-function lldb_rust_formatters.print_val ");
         script_str.push_str("-x \".*\" --category Rust\n");
@@ -765,9 +824,10 @@ actual:\n\
         // Set breakpoints on every line that contains the string "#break"
         let source_file_name = self.testpaths.file.file_name().unwrap().to_string_lossy();
         for line in &breakpoint_lines {
-            script_str.push_str(&format!("breakpoint set --file '{}' --line {}\n",
-                                         source_file_name,
-                                         line));
+            script_str.push_str(&format!(
+                "breakpoint set --file '{}' --line {}\n",
+                source_file_name, line
+            ));
         }
 
         // Append the other commands
@@ -785,9 +845,7 @@ actual:\n\
         let debugger_script = self.make_out_name("debugger.script");
 
         // Let LLDB execute the script via lldb_batchmode.py
-        let debugger_run_result = self.run_lldb(&exe_file,
-                                                &debugger_script,
-                                                &rust_src_root);
+        let debugger_run_result = self.run_lldb(&exe_file, &debugger_script, &rust_src_root);
 
         if !debugger_run_result.status.success() {
             self.fatal_proc_rec("Error while running LLDB", &debugger_run_result);
@@ -796,32 +854,39 @@ actual:\n\
         self.check_debugger_output(&debugger_run_result, &check_lines);
     }
 
-    fn run_lldb(&self,
-                test_executable: &Path,
-                debugger_script: &Path,
-                rust_src_root: &Path)
-                -> ProcRes {
+    fn run_lldb(
+        &self,
+        test_executable: &Path,
+        debugger_script: &Path,
+        rust_src_root: &Path,
+    ) -> ProcRes {
         // Prepare the lldb_batchmode which executes the debugger script
         let lldb_script_path = rust_src_root.join("src/etc/lldb_batchmode.py");
-        self.cmd2procres(Command::new(&self.config.lldb_python)
-                         .arg(&lldb_script_path)
-                         .arg(test_executable)
-                         .arg(debugger_script)
-                         .env("PYTHONPATH",
-                              self.config.lldb_python_dir.as_ref().unwrap()))
+        self.cmd2procres(
+            Command::new(&self.config.lldb_python)
+                .arg(&lldb_script_path)
+                .arg(test_executable)
+                .arg(debugger_script)
+                .env("PYTHONPATH", self.config.lldb_python_dir.as_ref().unwrap()),
+        )
     }
 
     fn cmd2procres(&self, cmd: &mut Command) -> ProcRes {
         let (status, out, err) = match cmd.output() {
-            Ok(Output { status, stdout, stderr }) => {
-                (status,
-                 String::from_utf8(stdout).unwrap(),
-                 String::from_utf8(stderr).unwrap())
-            },
-            Err(e) => {
-                self.fatal(&format!("Failed to setup Python process for \
-                                      LLDB script: {}", e))
-            }
+            Ok(Output {
+                status,
+                stdout,
+                stderr,
+            }) => (
+                status,
+                String::from_utf8(stdout).unwrap(),
+                String::from_utf8(stderr).unwrap(),
+            ),
+            Err(e) => self.fatal(&format!(
+                "Failed to setup Python process for \
+                                      LLDB script: {}",
+                e
+            )),
         };
 
         self.dump_output(&out, &err);
@@ -829,15 +894,15 @@ actual:\n\
             status,
             stdout: out,
             stderr: err,
-            cmdline: format!("{:?}", cmd)
+            cmdline: format!("{:?}", cmd),
         }
     }
 
     fn parse_debugger_commands(&self, debugger_prefixes: &[&str]) -> DebuggerCommands {
-        let directives = debugger_prefixes.iter().map(|prefix| (
-            format!("{}-command", prefix),
-            format!("{}-check", prefix),
-        )).collect::<Vec<_>>();
+        let directives = debugger_prefixes
+            .iter()
+            .map(|prefix| (format!("{}-command", prefix), format!("{}-check", prefix)))
+            .collect::<Vec<_>>();
 
         let mut breakpoint_lines = vec![];
         let mut commands = vec![];
@@ -852,22 +917,16 @@ actual:\n\
                     }
 
                     for &(ref command_directive, ref check_directive) in &directives {
-                        self.config.parse_name_value_directive(
-                            &line,
-                            command_directive).map(|cmd| {
-                                commands.push(cmd)
-                            });
+                        self.config
+                            .parse_name_value_directive(&line, command_directive)
+                            .map(|cmd| commands.push(cmd));
 
-                        self.config.parse_name_value_directive(
-                            &line,
-                            check_directive).map(|cmd| {
-                                check_lines.push(cmd)
-                            });
+                        self.config
+                            .parse_name_value_directive(&line, check_directive)
+                            .map(|cmd| check_lines.push(cmd));
                     }
                 }
-                Err(e) => {
-                    self.fatal(&format!("Error while parsing debugger commands: {}", e))
-                }
+                Err(e) => self.fatal(&format!("Error while parsing debugger commands: {}", e)),
             }
             counter += 1;
         }
@@ -885,15 +944,12 @@ actual:\n\
         }
 
         // Remove options that are either unwanted (-O) or may lead to duplicates due to RUSTFLAGS.
-        let options_to_remove = [
-            "-O".to_owned(),
-            "-g".to_owned(),
-            "--debuginfo".to_owned()
-        ];
-        let new_options =
-            self.split_maybe_args(options).into_iter()
-                                          .filter(|x| !options_to_remove.contains(x))
-                                          .collect::<Vec<String>>();
+        let options_to_remove = ["-O".to_owned(), "-g".to_owned(), "--debuginfo".to_owned()];
+        let new_options = self
+            .split_maybe_args(options)
+            .into_iter()
+            .filter(|x| !options_to_remove.contains(x))
+            .collect::<Vec<String>>();
 
         Some(new_options.join(" "))
     }
@@ -912,9 +968,13 @@ actual:\n\
             }
         }
         if check_line_index != num_check_lines && num_check_lines > 0 {
-            self.fatal_proc_rec(&format!("line not found in debugger output: {}",
-                                         check_lines[check_line_index]),
-                                debugger_run_result);
+            self.fatal_proc_rec(
+                &format!(
+                    "line not found in debugger output: {}",
+                    check_lines[check_line_index]
+                ),
+                debugger_run_result,
+            );
         }
 
         fn check_single_line(line: &str, check_line: &str) -> bool {
@@ -925,17 +985,18 @@ actual:\n\
             let can_start_anywhere = check_line.starts_with("[...]");
             let can_end_anywhere = check_line.ends_with("[...]");
 
-            let check_fragments: Vec<&str> = check_line.split("[...]")
-                                                       .filter(|frag| !frag.is_empty())
-                                                       .collect();
+            let check_fragments: Vec<&str> = check_line
+                .split("[...]")
+                .filter(|frag| !frag.is_empty())
+                .collect();
             if check_fragments.is_empty() {
                 return true;
             }
 
             let (mut rest, first_fragment) = if can_start_anywhere {
                 match line.find(check_fragments[0]) {
-                    Some(pos) => (&line[pos + check_fragments[0].len() ..], 1),
-                    None => return false
+                    Some(pos) => (&line[pos + check_fragments[0].len()..], 1),
+                    None => return false,
                 }
             } else {
                 (line, 0)
@@ -944,9 +1005,9 @@ actual:\n\
             for current_fragment in &check_fragments[first_fragment..] {
                 match rest.find(current_fragment) {
                     Some(pos) => {
-                        rest = &rest[pos + current_fragment.len() .. ];
+                        rest = &rest[pos + current_fragment.len()..];
                     }
-                    None => return false
+                    None => return false,
                 }
             }
 
@@ -958,15 +1019,15 @@ actual:\n\
         }
     }
 
-    fn check_error_patterns(&self,
-                            output_to_check: &str,
-                            proc_res: &ProcRes) {
+    fn check_error_patterns(&self, output_to_check: &str, proc_res: &ProcRes) {
         if self.props.error_patterns.is_empty() {
             if self.props.must_compile_successfully {
-                return
+                return;
             } else {
-                self.fatal(&format!("no error pattern specified in {:?}",
-                                    self.testpaths.file.display()));
+                self.fatal(&format!(
+                    "no error pattern specified in {:?}",
+                    self.testpaths.file.display()
+                ));
             }
         }
         let mut next_err_idx = 0;
@@ -984,13 +1045,16 @@ actual:\n\
                 next_err_pat = self.props.error_patterns[next_err_idx].trim();
             }
         }
-        if done { return; }
+        if done {
+            return;
+        }
 
         let missing_patterns = &self.props.error_patterns[next_err_idx..];
         if missing_patterns.len() == 1 {
             self.fatal_proc_rec(
                 &format!("error pattern '{}' not found!", missing_patterns[0]),
-                proc_res);
+                proc_res,
+            );
         } else {
             for pattern in missing_patterns {
                 self.error(&format!("error pattern '{}' not found!", *pattern));
@@ -1007,9 +1071,7 @@ actual:\n\
         }
     }
 
-    fn check_forbid_output(&self,
-                           output_to_check: &str,
-                           proc_res: &ProcRes) {
+    fn check_forbid_output(&self, output_to_check: &str, proc_res: &ProcRes) {
         for pat in &self.props.forbid_output {
             if output_to_check.contains(pat) {
                 self.fatal_proc_rec("forbidden pattern found in compiler output", proc_res);
@@ -1017,11 +1079,12 @@ actual:\n\
         }
     }
 
-    fn check_expected_errors(&self,
-                             expected_errors: Vec<errors::Error>,
-                             proc_res: &ProcRes) {
-        if proc_res.status.success() &&
-            expected_errors.iter().any(|x| x.kind == Some(ErrorKind::Error)) {
+    fn check_expected_errors(&self, expected_errors: Vec<errors::Error>, proc_res: &ProcRes) {
+        if proc_res.status.success()
+            && expected_errors
+                .iter()
+                .any(|x| x.kind == Some(ErrorKind::Error))
+        {
             self.fatal_proc_rec("process did not return an error status", proc_res);
         }
 
@@ -1029,16 +1092,18 @@ actual:\n\
         // from the compiler
         let os_file_name = self.testpaths.file.display().to_string();
 
-        let file_name =
-            format!("{}", self.testpaths.file.display())
-            .replace(r"\", "/"); // on windows, translate all '\' path separators to '/'
+        let file_name = format!("{}", self.testpaths.file.display()).replace(r"\", "/"); // on windows, translate all '\' path separators to '/'
 
         // If the testcase being checked contains at least one expected "help"
         // message, then we'll ensure that all "help" messages are expected.
         // Otherwise, all "help" messages reported by the compiler will be ignored.
         // This logic also applies to "note" messages.
-        let expect_help = expected_errors.iter().any(|ee| ee.kind == Some(ErrorKind::Help));
-        let expect_note = expected_errors.iter().any(|ee| ee.kind == Some(ErrorKind::Note));
+        let expect_help = expected_errors
+            .iter()
+            .any(|ee| ee.kind == Some(ErrorKind::Help));
+        let expect_note = expected_errors
+            .iter()
+            .any(|ee| ee.kind == Some(ErrorKind::Note));
 
         // Parse the JSON output from the compiler and extract out the messages.
         let actual_errors = json::parse_output(&os_file_name, &proc_res.stderr, proc_res);
@@ -1047,15 +1112,15 @@ actual:\n\
         for actual_error in &actual_errors {
             let opt_index =
                 expected_errors
-                .iter()
-                .enumerate()
-                .position(|(index, expected_error)| {
-                    !found[index] &&
-                        actual_error.line_num == expected_error.line_num &&
-                        (expected_error.kind.is_none() ||
-                         actual_error.kind == expected_error.kind) &&
-                        actual_error.msg.contains(&expected_error.msg)
-                });
+                    .iter()
+                    .enumerate()
+                    .position(|(index, expected_error)| {
+                        !found[index]
+                            && actual_error.line_num == expected_error.line_num
+                            && (expected_error.kind.is_none()
+                                || actual_error.kind == expected_error.kind)
+                            && actual_error.msg.contains(&expected_error.msg)
+                    });
 
             match opt_index {
                 Some(index) => {
@@ -1066,14 +1131,16 @@ actual:\n\
 
                 None => {
                     if self.is_unexpected_compiler_message(actual_error, expect_help, expect_note) {
-                        self.error(
-                            &format!("{}:{}: unexpected {}: '{}'",
-                                     file_name,
-                                     actual_error.line_num,
-                                     actual_error.kind.as_ref()
-                                     .map_or(String::from("message"),
-                                             |k| k.to_string()),
-                                     actual_error.msg));
+                        self.error(&format!(
+                            "{}:{}: unexpected {}: '{}'",
+                            file_name,
+                            actual_error.line_num,
+                            actual_error
+                                .kind
+                                .as_ref()
+                                .map_or(String::from("message"), |k| k.to_string()),
+                            actual_error.msg
+                        ));
                         unexpected.push(actual_error);
                     }
                 }
@@ -1084,24 +1151,27 @@ actual:\n\
         // anything not yet found is a problem
         for (index, expected_error) in expected_errors.iter().enumerate() {
             if !found[index] {
-                self.error(
-                    &format!("{}:{}: expected {} not found: {}",
-                             file_name,
-                             expected_error.line_num,
-                             expected_error.kind.as_ref()
-                             .map_or("message".into(),
-                                     |k| k.to_string()),
-                             expected_error.msg));
+                self.error(&format!(
+                    "{}:{}: expected {} not found: {}",
+                    file_name,
+                    expected_error.line_num,
+                    expected_error
+                        .kind
+                        .as_ref()
+                        .map_or("message".into(), |k| k.to_string()),
+                    expected_error.msg
+                ));
                 not_found.push(expected_error);
             }
         }
 
         if !unexpected.is_empty() || !not_found.is_empty() {
-            self.error(
-                &format!("{} unexpected errors found, {} expected errors not found",
-                         unexpected.len(), not_found.len()));
-            println!("status: {}\ncommand: {}",
-                   proc_res.status, proc_res.cmdline);
+            self.error(&format!(
+                "{} unexpected errors found, {} expected errors not found",
+                unexpected.len(),
+                not_found.len()
+            ));
+            println!("status: {}\ncommand: {}", proc_res.status, proc_res.cmdline);
             if !unexpected.is_empty() {
                 println!("unexpected errors (from JSON output): {:#?}\n", unexpected);
             }
@@ -1116,18 +1186,17 @@ actual:\n\
     /// which did not match any of the expected error. We always require
     /// errors/warnings to be explicitly listed, but only require
     /// helps/notes if there are explicit helps/notes given.
-    fn is_unexpected_compiler_message(&self,
-                                      actual_error: &Error,
-                                      expect_help: bool,
-                                      expect_note: bool)
-                                      -> bool {
+    fn is_unexpected_compiler_message(
+        &self,
+        actual_error: &Error,
+        expect_help: bool,
+        expect_note: bool,
+    ) -> bool {
         match actual_error.kind {
             Some(ErrorKind::Help) => expect_help,
             Some(ErrorKind::Note) => expect_note,
-            Some(ErrorKind::Error) |
-            Some(ErrorKind::Warning) => true,
-            Some(ErrorKind::Suggestion) |
-            None => false
+            Some(ErrorKind::Error) | Some(ErrorKind::Warning) => true,
+            Some(ErrorKind::Suggestion) | None => false,
         }
     }
 
@@ -1141,11 +1210,14 @@ actual:\n\
                 // can turn it back on if needed.
                 AllowUnused::Yes
             }
-            _ => AllowUnused::No
+            _ => AllowUnused::No,
         };
 
         let mut rustc = self.make_compile_args(
-            &self.testpaths.file, TargetLocation::ThisFile(self.make_exe_name()), allow_unused);
+            &self.testpaths.file,
+            TargetLocation::ThisFile(self.make_exe_name()),
+            allow_unused,
+        );
 
         rustc.arg("-L").arg(&self.aux_output_dir_name());
 
@@ -1156,14 +1228,14 @@ actual:\n\
         if self.props.build_aux_docs {
             for rel_ab in &self.props.aux_builds {
                 let aux_testpaths = self.compute_aux_test_paths(rel_ab);
-                let aux_props = self.props.from_aux_file(&aux_testpaths.file,
-                                                         self.revision,
-                                                         self.config);
+                let aux_props =
+                    self.props
+                        .from_aux_file(&aux_testpaths.file, self.revision, self.config);
                 let aux_cx = TestCx {
                     config: self.config,
                     props: &aux_props,
                     testpaths: &aux_testpaths,
-                    revision: self.revision
+                    revision: self.revision,
                 };
                 let auxres = aux_cx.document(out_dir);
                 if !auxres.status.success() {
@@ -1174,15 +1246,26 @@ actual:\n\
 
         let aux_dir = self.aux_output_dir_name();
 
-        let rustdoc_path = self.config.rustdoc_path.as_ref().expect("--rustdoc-path passed");
+        let rustdoc_path = self
+            .config
+            .rustdoc_path
+            .as_ref()
+            .expect("--rustdoc-path passed");
         let mut rustdoc = Command::new(rustdoc_path);
 
-        rustdoc.arg("-L").arg(aux_dir)
-            .arg("-o").arg(out_dir)
+        rustdoc
+            .arg("-L")
+            .arg(aux_dir)
+            .arg("-o")
+            .arg(out_dir)
             .arg(&self.testpaths.file)
             .args(&self.props.compile_flags);
         if let Some(ref linker) = self.config.linker {
-            rustdoc.arg("--linker").arg(linker).arg("-Z").arg("unstable-options");
+            rustdoc
+                .arg("--linker")
+                .arg(linker)
+                .arg("-Z")
+                .arg("unstable-options");
         }
 
         self.compose_and_run_compiler(rustdoc, None)
@@ -1212,34 +1295,39 @@ actual:\n\
                     for entry in entries {
                         let entry = entry.unwrap();
                         if !entry.path().is_file() {
-                            continue
+                            continue;
                         }
                         prog.push_str(":");
                         prog.push_str(entry.path().to_str().unwrap());
                     }
                 }
-                let mut test_client = Command::new(
-                    self.config.remote_test_client.as_ref().unwrap());
+                let mut test_client =
+                    Command::new(self.config.remote_test_client.as_ref().unwrap());
                 test_client
                     .args(&["run", &prog])
                     .args(args)
                     .envs(env.clone());
-                self.compose_and_run(test_client,
-                                     self.config.run_lib_path.to_str().unwrap(),
-                                     Some(aux_dir.to_str().unwrap()),
-                                     None)
+                self.compose_and_run(
+                    test_client,
+                    self.config.run_lib_path.to_str().unwrap(),
+                    Some(aux_dir.to_str().unwrap()),
+                    None,
+                )
             }
             _ => {
                 let aux_dir = self.aux_output_dir_name();
                 let ProcArgs { prog, args } = self.make_run_args();
                 let mut program = Command::new(&prog);
-                program.args(args)
+                program
+                    .args(args)
                     .current_dir(&self.output_base_name().parent().unwrap())
                     .envs(env.clone());
-                self.compose_and_run(program,
-                                     self.config.run_lib_path.to_str().unwrap(),
-                                     Some(aux_dir.to_str().unwrap()),
-                                     None)
+                self.compose_and_run(
+                    program,
+                    self.config.run_lib_path.to_str().unwrap(),
+                    Some(aux_dir.to_str().unwrap()),
+                    None,
+                )
             }
         }
     }
@@ -1247,24 +1335,31 @@ actual:\n\
     /// For each `aux-build: foo/bar` annotation, we check to find the
     /// file in a `aux` directory relative to the test itself.
     fn compute_aux_test_paths(&self, rel_ab: &str) -> TestPaths {
-        let test_ab = self.testpaths.file
-                                    .parent()
-                                    .expect("test file path has no parent")
-                                    .join("auxiliary")
-                                    .join(rel_ab);
+        let test_ab = self
+            .testpaths
+            .file
+            .parent()
+            .expect("test file path has no parent")
+            .join("auxiliary")
+            .join(rel_ab);
         if !test_ab.exists() {
-            self.fatal(&format!("aux-build `{}` source not found", test_ab.display()))
+            self.fatal(&format!(
+                "aux-build `{}` source not found",
+                test_ab.display()
+            ))
         }
 
         TestPaths {
             file: test_ab,
             base: self.testpaths.base.clone(),
-            relative_dir: self.testpaths.relative_dir
-                                        .join("auxiliary")
-                                        .join(rel_ab)
-                                        .parent()
-                                        .expect("aux-build path has no parent")
-                                        .to_path_buf()
+            relative_dir: self
+                .testpaths
+                .relative_dir
+                .join("auxiliary")
+                .join(rel_ab)
+                .parent()
+                .expect("aux-build path has no parent")
+                .to_path_buf(),
         }
     }
 
@@ -1277,9 +1372,9 @@ actual:\n\
 
         for rel_ab in &self.props.aux_builds {
             let aux_testpaths = self.compute_aux_test_paths(rel_ab);
-            let aux_props = self.props.from_aux_file(&aux_testpaths.file,
-                                                     self.revision,
-                                                     self.config);
+            let aux_props =
+                self.props
+                    .from_aux_file(&aux_testpaths.file, self.revision, self.config);
             let aux_output = {
                 let f = self.make_lib_name(&self.testpaths.file);
                 let parent = f.parent().unwrap();
@@ -1289,15 +1384,17 @@ actual:\n\
                 config: self.config,
                 props: &aux_props,
                 testpaths: &aux_testpaths,
-                revision: self.revision
+                revision: self.revision,
             };
-            let mut aux_rustc = aux_cx.make_compile_args(&aux_testpaths.file, aux_output, AllowUnused::No);
+            let mut aux_rustc =
+                aux_cx.make_compile_args(&aux_testpaths.file, aux_output, AllowUnused::No);
 
             let crate_type = if aux_props.no_prefer_dynamic {
                 None
-            } else if (self.config.target.contains("musl") && !aux_props.force_host) ||
-                      self.config.target.contains("wasm32") ||
-                      self.config.target.contains("emscripten") {
+            } else if (self.config.target.contains("musl") && !aux_props.force_host)
+                || self.config.target.contains("wasm32")
+                || self.config.target.contains("emscripten")
+            {
                 // We primarily compile all auxiliary libraries as dynamic libraries
                 // to avoid code size bloat and large binaries as much as possible
                 // for the test suite (otherwise including libstd statically in all
@@ -1318,32 +1415,40 @@ actual:\n\
 
             aux_rustc.arg("-L").arg(&aux_dir);
 
-            let auxres = aux_cx.compose_and_run(aux_rustc,
-                                                aux_cx.config.compile_lib_path.to_str().unwrap(),
-                                                Some(aux_dir.to_str().unwrap()),
-                                                None);
+            let auxres = aux_cx.compose_and_run(
+                aux_rustc,
+                aux_cx.config.compile_lib_path.to_str().unwrap(),
+                Some(aux_dir.to_str().unwrap()),
+                None,
+            );
             if !auxres.status.success() {
                 self.fatal_proc_rec(
-                    &format!("auxiliary build of {:?} failed to compile: ",
-                             aux_testpaths.file.display()),
-                    &auxres);
+                    &format!(
+                        "auxiliary build of {:?} failed to compile: ",
+                        aux_testpaths.file.display()
+                    ),
+                    &auxres,
+                );
             }
         }
 
         rustc.envs(self.props.rustc_env.clone());
-        self.compose_and_run(rustc,
-                             self.config.compile_lib_path.to_str().unwrap(),
-                             Some(aux_dir.to_str().unwrap()),
-                             input)
+        self.compose_and_run(
+            rustc,
+            self.config.compile_lib_path.to_str().unwrap(),
+            Some(aux_dir.to_str().unwrap()),
+            input,
+        )
     }
 
-    fn compose_and_run(&self,
-                       mut command: Command,
-                       lib_path: &str,
-                       aux_path: Option<&str>,
-                       input: Option<String>) -> ProcRes {
-        let cmdline =
-        {
+    fn compose_and_run(
+        &self,
+        mut command: Command,
+        lib_path: &str,
+        aux_path: Option<&str>,
+        input: Option<String>,
+    ) -> ProcRes {
+        let cmdline = {
             let cmdline = self.make_cmdline(&command, lib_path);
             logv(self.config, format!("executing {}", cmdline));
             cmdline
@@ -1367,13 +1472,23 @@ actual:\n\
         let newpath = env::join_paths(&path).unwrap();
         command.env(dylib_env_var(), newpath);
 
-        let mut child = command.spawn().expect(&format!("failed to exec `{:?}`", &command));
+        let mut child = command
+            .spawn()
+            .expect(&format!("failed to exec `{:?}`", &command));
         if let Some(input) = input {
-            child.stdin.as_mut().unwrap().write_all(input.as_bytes()).unwrap();
+            child
+                .stdin
+                .as_mut()
+                .unwrap()
+                .write_all(input.as_bytes())
+                .unwrap();
         }
 
-        let Output { status, stdout, stderr } = read2_abbreviated(child)
-            .expect("failed to read output");
+        let Output {
+            status,
+            stdout,
+            stderr,
+        } = read2_abbreviated(child).expect("failed to read output");
 
         let result = ProcRes {
             status,
@@ -1387,13 +1502,19 @@ actual:\n\
         result
     }
 
-    fn make_compile_args(&self, input_file: &Path, output_file: TargetLocation, allow_unused: AllowUnused) -> Command {
+    fn make_compile_args(
+        &self,
+        input_file: &Path,
+        output_file: TargetLocation,
+        allow_unused: AllowUnused,
+    ) -> Command {
         let mut rustc = Command::new(&self.config.rustc_path);
-        rustc.arg(input_file)
-            .arg("-L").arg(&self.config.build_base);
+        rustc.arg(input_file).arg("-L").arg(&self.config.build_base);
 
         // Optionally prevent default --target if specified in test compile-flags.
-        let custom_target = self.props.compile_flags
+        let custom_target = self
+            .props
+            .compile_flags
             .iter()
             .fold(false, |acc, x| acc || x.starts_with("--target"));
 
@@ -1418,9 +1539,7 @@ actual:\n\
         }
 
         match self.config.mode {
-            CompileFail |
-            ParseFail |
-            Incremental => {
+            CompileFail | ParseFail | Incremental => {
                 // If we are extracting and matching errors in the new
                 // fashion, then you want JSON mode. Old-skool error
                 // patterns still match the raw compiler output.
@@ -1432,7 +1551,8 @@ actual:\n\
                 rustc.args(&[
                     "-Zdump-mir=all",
                     "-Zmir-opt-level=3",
-                    "-Zdump-mir-exclude-pass-number"]);
+                    "-Zdump-mir-exclude-pass-number",
+                ]);
 
                 let mir_dump_dir = self.get_mir_dump_dir();
                 let _ = fs::remove_dir_all(&mir_dump_dir);
@@ -1453,20 +1573,11 @@ actual:\n\
                     rustc.args(&["--error-format", "json"]);
                 }
             }
-            RunFail |
-            RunPassValgrind |
-            Pretty |
-            DebugInfoGdb |
-            DebugInfoLldb |
-            Codegen |
-            Rustdoc |
-            RunMake |
-            CodegenUnits |
-            Assembly => {
+            RunFail | RunPassValgrind | Pretty | DebugInfoGdb | DebugInfoLldb | Codegen
+            | Rustdoc | RunMake | CodegenUnits | Assembly => {
                 // do not use JSON output
             }
         }
-
 
         if self.config.target == "wasm32-unknown-unknown" {
             // rustc.arg("-g"); // get any backtrace at all on errors
@@ -1556,10 +1667,15 @@ actual:\n\
                 self.fatal("no NodeJS binary found (--nodejs)");
             }
 
-            let src = self.config.src_base
-                .parent().unwrap() // chop off `run-pass`
-                .parent().unwrap() // chop off `test`
-                .parent().unwrap(); // chop off `src`
+            let src = self
+                .config
+                .src_base
+                .parent()
+                .unwrap() // chop off `run-pass`
+                .parent()
+                .unwrap() // chop off `test`
+                .parent()
+                .unwrap(); // chop off `src`
             args.push(src.join("src/etc/wasm32-shim.js").display().to_string());
         }
 
@@ -1572,26 +1688,22 @@ actual:\n\
         args.extend(self.split_maybe_args(&self.props.run_flags));
 
         let prog = args.remove(0);
-         ProcArgs {
-            prog,
-            args,
-        }
+        ProcArgs { prog, args }
     }
 
     fn split_maybe_args(&self, argstr: &Option<String>) -> Vec<String> {
         match *argstr {
-            Some(ref s) => {
-                s
-                    .split(' ')
-                    .filter_map(|s| {
-                        if s.chars().all(|c| c.is_whitespace()) {
-                            None
-                        } else {
-                            Some(s.to_owned())
-                        }
-                    }).collect()
-            }
-            None => Vec::new()
+            Some(ref s) => s
+                .split(' ')
+                .filter_map(|s| {
+                    if s.chars().all(|c| c.is_whitespace()) {
+                        None
+                    } else {
+                        Some(s.to_owned())
+                    }
+                })
+                .collect(),
+            None => Vec::new(),
         }
     }
 
@@ -1605,7 +1717,11 @@ actual:\n\
             // Build the LD_LIBRARY_PATH variable as it would be seen on the command line
             // for diagnostic purposes
             fn lib_path_cmd_prefix(path: &str) -> String {
-                format!("{}=\"{}\"", util::lib_path_env_var(), util::make_new_path(path))
+                format!(
+                    "{}=\"{}\"",
+                    util::lib_path_env_var(),
+                    util::make_new_path(path)
+                )
             }
 
             format!("{} {:?}", lib_path_cmd_prefix(libpath), command)
@@ -1624,11 +1740,12 @@ actual:\n\
         self.maybe_dump_to_stdout(out, err);
     }
 
-    fn dump_output_file(&self,
-                        out: &str,
-                        extension: &str) {
+    fn dump_output_file(&self, out: &str, extension: &str) {
         let outfile = self.make_out_name(extension);
-        File::create(&outfile).unwrap().write_all(out.as_bytes()).unwrap();
+        File::create(&outfile)
+            .unwrap()
+            .write_all(out.as_bytes())
+            .unwrap();
     }
 
     fn make_out_name(&self, extension: &str) -> PathBuf {
@@ -1652,8 +1769,7 @@ actual:\n\
         let dir = self.config.build_base.join(&self.testpaths.relative_dir);
 
         // Note: The directory `dir` is created during `collect_tests_from_dir`
-        dir
-            .join(&self.output_testname(&self.testpaths.file))
+        dir.join(&self.output_testname(&self.testpaths.file))
             .with_extension(&self.config.stage_id)
     }
 
@@ -1670,12 +1786,13 @@ actual:\n\
     fn error(&self, err: &str) {
         match self.revision {
             Some(rev) => println!("\nerror in revision `{}`: {}", rev, err),
-            None => println!("\nerror: {}", err)
+            None => println!("\nerror: {}", err),
         }
     }
 
     fn fatal(&self, err: &str) -> ! {
-        self.error(err); panic!();
+        self.error(err);
+        panic!();
     }
 
     fn fatal_proc_rec(&self, err: &str, proc_res: &ProcRes) -> ! {
@@ -1691,10 +1808,10 @@ actual:\n\
     // errors here.
     fn try_print_open_handles(&self) {
         if !cfg!(windows) {
-            return
+            return;
         }
         if self.config.mode != Incremental {
-            return
+            return;
         }
 
         let filename = match self.testpaths.file.file_stem() {
@@ -1728,11 +1845,10 @@ actual:\n\
     fn compile_test_and_save_ir(&self) -> ProcRes {
         let aux_dir = self.aux_output_dir_name();
 
-        let output_file = TargetLocation::ThisDirectory(
-            self.output_base_name().parent().unwrap().to_path_buf());
+        let output_file =
+            TargetLocation::ThisDirectory(self.output_base_name().parent().unwrap().to_path_buf());
         let mut rustc = self.make_compile_args(&self.testpaths.file, output_file, AllowUnused::No);
-        rustc.arg("-L").arg(aux_dir)
-            .arg("--emit=llvm-ir");
+        rustc.arg("-L").arg(aux_dir).arg("--emit=llvm-ir");
 
         self.compose_and_run_compiler(rustc, None)
     }
@@ -1769,7 +1885,9 @@ actual:\n\
 
     fn verify_with_filecheck(&self, output: &Path) -> ProcRes {
         let mut filecheck = Command::new(self.config.llvm_filecheck.as_ref().unwrap());
-        filecheck.arg("--input-file").arg(output)
+        filecheck
+            .arg("--input-file")
+            .arg(output)
             .arg(&self.testpaths.file);
         self.compose_and_run(filecheck, "", None, None)
     }
@@ -1848,105 +1966,122 @@ actual:\n\
         }
     }
 
-    fn get_lines<P: AsRef<Path>>(&self, path: &P,
-                                 mut other_files: Option<&mut Vec<String>>) -> Vec<usize> {
-        let mut file = fs::File::open(path)
-                                .expect("markdown_test_output_check_entry File::open failed");
+    fn get_lines<P: AsRef<Path>>(
+        &self,
+        path: &P,
+        mut other_files: Option<&mut Vec<String>>,
+    ) -> Vec<usize> {
+        let mut file =
+            fs::File::open(path).expect("markdown_test_output_check_entry File::open failed");
         let mut content = String::new();
         file.read_to_string(&mut content)
             .expect("markdown_test_output_check_entry read_to_string failed");
         let mut ignore = false;
-        content.lines()
-               .enumerate()
-               .filter_map(|(line_nb, line)| {
-                   if (line.trim_start().starts_with("pub mod ") ||
-                       line.trim_start().starts_with("mod ")) &&
-                      line.ends_with(';') {
-                       if let Some(ref mut other_files) = other_files {
-                           other_files.push(line.rsplit("mod ")
-                                      .next()
-                                      .unwrap()
-                                      .replace(";", ""));
-                       }
-                       None
-                   } else {
-                       let sline = line.split("///").last().unwrap_or("");
-                       let line = sline.trim_start();
-                       if line.starts_with("```") {
-                           if ignore {
-                               ignore = false;
-                               None
-                           } else {
-                               ignore = true;
-                               Some(line_nb + 1)
-                           }
-                       } else {
-                           None
-                       }
-                   }
-               })
-               .collect()
+        content
+            .lines()
+            .enumerate()
+            .filter_map(|(line_nb, line)| {
+                if (line.trim_start().starts_with("pub mod ")
+                    || line.trim_start().starts_with("mod "))
+                    && line.ends_with(';')
+                {
+                    if let Some(ref mut other_files) = other_files {
+                        other_files.push(line.rsplit("mod ").next().unwrap().replace(";", ""));
+                    }
+                    None
+                } else {
+                    let sline = line.split("///").last().unwrap_or("");
+                    let line = sline.trim_start();
+                    if line.starts_with("```") {
+                        if ignore {
+                            ignore = false;
+                            None
+                        } else {
+                            ignore = true;
+                            Some(line_nb + 1)
+                        }
+                    } else {
+                        None
+                    }
+                }
+            })
+            .collect()
     }
 
     fn check_rustdoc_test_option(&self, res: ProcRes) {
         let mut other_files = Vec::new();
         let mut files: HashMap<String, Vec<usize>> = HashMap::new();
         let cwd = env::current_dir().unwrap();
-        files.insert(self.testpaths.file.strip_prefix(&cwd)
-                                        .unwrap_or(&self.testpaths.file)
-                                        .to_str()
-                                        .unwrap()
-                                        .replace('\\', "/"),
-                     self.get_lines(&self.testpaths.file, Some(&mut other_files)));
+        files.insert(
+            self.testpaths
+                .file
+                .strip_prefix(&cwd)
+                .unwrap_or(&self.testpaths.file)
+                .to_str()
+                .unwrap()
+                .replace('\\', "/"),
+            self.get_lines(&self.testpaths.file, Some(&mut other_files)),
+        );
         for other_file in other_files {
             let mut path = self.testpaths.file.clone();
             path.set_file_name(&format!("{}.rs", other_file));
-            files.insert(path.strip_prefix(&cwd)
-                             .unwrap_or(&path)
-                             .to_str()
-                             .unwrap()
-                             .replace('\\', "/"),
-                         self.get_lines(&path, None));
+            files.insert(
+                path.strip_prefix(&cwd)
+                    .unwrap_or(&path)
+                    .to_str()
+                    .unwrap()
+                    .replace('\\', "/"),
+                self.get_lines(&path, None),
+            );
         }
 
         let mut tested = 0;
-        for _ in res.stdout.split('\n')
-                           .filter(|s| s.starts_with("test "))
-                           .inspect(|s| {
-                               let tmp: Vec<&str> = s.split(" - ").collect();
-                               if tmp.len() == 2 {
-                                   let path = tmp[0].rsplit("test ").next().unwrap();
-                                   if let Some(ref mut v) = files.get_mut(
-                                                                &path.replace('\\', "/")) {
-                                       tested += 1;
-                                       let mut iter = tmp[1].split("(line ");
-                                       iter.next();
-                                       let line = iter.next()
-                                                      .unwrap_or(")")
-                                                      .split(')')
-                                                      .next()
-                                                      .unwrap_or("0")
-                                                      .parse()
-                                                      .unwrap_or(0);
-                                       if let Ok(pos) = v.binary_search(&line) {
-                                           v.remove(pos);
-                                       } else {
-                                           self.fatal_proc_rec(
-                                               &format!("Not found doc test: \"{}\" in \"{}\":{:?}",
-                                                        s, path, v),
-                                               &res);
-                                       }
-                                   }
-                               }
-                           }) {}
+        for _ in res
+            .stdout
+            .split('\n')
+            .filter(|s| s.starts_with("test "))
+            .inspect(|s| {
+                let tmp: Vec<&str> = s.split(" - ").collect();
+                if tmp.len() == 2 {
+                    let path = tmp[0].rsplit("test ").next().unwrap();
+                    if let Some(ref mut v) = files.get_mut(&path.replace('\\', "/")) {
+                        tested += 1;
+                        let mut iter = tmp[1].split("(line ");
+                        iter.next();
+                        let line = iter
+                            .next()
+                            .unwrap_or(")")
+                            .split(')')
+                            .next()
+                            .unwrap_or("0")
+                            .parse()
+                            .unwrap_or(0);
+                        if let Ok(pos) = v.binary_search(&line) {
+                            v.remove(pos);
+                        } else {
+                            self.fatal_proc_rec(
+                                &format!("Not found doc test: \"{}\" in \"{}\":{:?}", s, path, v),
+                                &res,
+                            );
+                        }
+                    }
+                }
+            })
+        {}
         if tested == 0 {
             self.fatal_proc_rec(&format!("No test has been found... {:?}", files), &res);
         } else {
             for (entry, v) in &files {
                 if !v.is_empty() {
-                    self.fatal_proc_rec(&format!("Not found test at line{} \"{}\":{:?}",
-                                                 if v.len() > 1 { "s" } else { "" }, entry, v),
-                                        &res);
+                    self.fatal_proc_rec(
+                        &format!(
+                            "Not found test at line{} \"{}\":{:?}",
+                            if v.len() > 1 { "s" } else { "" },
+                            entry,
+                            v
+                        ),
+                        &res,
+                    );
                 }
             }
         }
@@ -1982,13 +2117,13 @@ actual:\n\
         let mut wrong_cgus = Vec::new();
 
         for expected_item in &expected {
-            let actual_item_with_same_name = actual.iter()
-                                                   .find(|ti| ti.name == expected_item.name);
+            let actual_item_with_same_name = actual.iter().find(|ti| ti.name == expected_item.name);
 
             if let Some(actual_item) = actual_item_with_same_name {
                 if !expected_item.codegen_units.is_empty() &&
                    // Also check for codegen units
-                   expected_item.codegen_units != actual_item.codegen_units {
+                   expected_item.codegen_units != actual_item.codegen_units
+                {
                     wrong_cgus.push((expected_item.clone(), actual_item.clone()));
                 }
             } else {
@@ -1996,11 +2131,11 @@ actual:\n\
             }
         }
 
-        let unexpected: Vec<_> =
-            actual.iter()
-                  .filter(|acgu| !expected.iter().any(|ecgu| acgu.name == ecgu.name))
-                  .map(|acgu| acgu.string.clone())
-                  .collect();
+        let unexpected: Vec<_> = actual
+            .iter()
+            .filter(|acgu| !expected.iter().any(|ecgu| acgu.name == ecgu.name))
+            .map(|acgu| acgu.string.clone())
+            .collect();
 
         if !missing.is_empty() {
             missing.sort();
@@ -2036,14 +2171,19 @@ actual:\n\
 
             for &(ref expected_item, ref actual_item) in &wrong_cgus {
                 println!("{}", expected_item.name);
-                println!("  expected: {}", codegen_units_to_str(&expected_item.codegen_units));
-                println!("  actual:   {}", codegen_units_to_str(&actual_item.codegen_units));
+                println!(
+                    "  expected: {}",
+                    codegen_units_to_str(&expected_item.codegen_units)
+                );
+                println!(
+                    "  actual:   {}",
+                    codegen_units_to_str(&actual_item.codegen_units)
+                );
                 println!("");
             }
         }
 
-        if !(missing.is_empty() && unexpected.is_empty() && wrong_cgus.is_empty())
-        {
+        if !(missing.is_empty() && unexpected.is_empty() && wrong_cgus.is_empty()) {
             panic!();
         }
 
@@ -2064,23 +2204,24 @@ actual:\n\
 
             let full_string = format!("{}{}", PREFIX, s.trim().to_owned());
 
-            let parts: Vec<&str> = s.split(CGU_MARKER)
-                                    .map(str::trim)
-                                    .filter(|s| !s.is_empty())
-                                    .collect();
+            let parts: Vec<&str> = s
+                .split(CGU_MARKER)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect();
 
             let name = parts[0].trim();
 
             let cgus = if parts.len() > 1 {
                 let cgus_str = parts[1];
 
-                cgus_str.split(' ')
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty())
-                        .map(str::to_owned)
-                        .collect()
-            }
-            else {
+                cgus_str
+                    .split(' ')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned)
+                    .collect()
+            } else {
                 HashSet::new()
             };
 
@@ -2091,8 +2232,7 @@ actual:\n\
             }
         }
 
-        fn codegen_units_to_str(cgus: &HashSet<String>) -> String
-        {
+        fn codegen_units_to_str(cgus: &HashSet<String>) -> String {
             let mut cgus: Vec<_> = cgus.iter().collect();
             cgus.sort();
 
@@ -2123,7 +2263,10 @@ actual:\n\
         fs::create_dir_all(&incremental_dir).unwrap();
 
         if self.config.verbose {
-            print!("init_incremental_test: incremental_dir={}", incremental_dir.display());
+            print!(
+                "init_incremental_test: incremental_dir={}",
+                incremental_dir.display()
+            );
         }
     }
 
@@ -2147,11 +2290,16 @@ actual:\n\
         // FIXME -- use non-incremental mode as an oracle? That doesn't apply
         // to #[rustc_dirty] and clean tests I guess
 
-        let revision = self.revision.expect("incremental tests require a list of revisions");
+        let revision = self
+            .revision
+            .expect("incremental tests require a list of revisions");
 
         // Incremental workproduct directory should have already been created.
         let incremental_dir = self.incremental_dir();
-        assert!(incremental_dir.exists(), "init_incremental_test failed to create incremental dir");
+        assert!(
+            incremental_dir.exists(),
+            "init_incremental_test failed to create incremental dir"
+        );
 
         // Add an extra flag pointing at the incremental directory.
         let mut revision_props = self.props.clone();
@@ -2165,7 +2313,10 @@ actual:\n\
         };
 
         if self.config.verbose {
-            print!("revision={:?} revision_props={:#?}", revision, revision_props);
+            print!(
+                "revision={:?} revision_props={:#?}",
+                revision, revision_props
+            );
         }
 
         if revision.starts_with("rpass") {
@@ -2175,8 +2326,7 @@ actual:\n\
         } else if revision.starts_with("cfail") {
             revision_cx.run_cfail_test();
         } else {
-            revision_cx.fatal(
-                "revision name must begin with rpass, rfail, or cfail");
+            revision_cx.fatal("revision name must begin with rpass, rfail, or cfail");
         }
     }
 
@@ -2188,13 +2338,19 @@ actual:\n\
     fn run_rmake_test(&self) {
         // FIXME(#11094): we should fix these tests
         if self.config.host != self.config.target {
-            return
+            return;
         }
 
         let cwd = env::current_dir().unwrap();
-        let src_root = self.config.src_base.parent().unwrap()
-                                           .parent().unwrap()
-                                           .parent().unwrap();
+        let src_root = self
+            .config
+            .src_base
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
         let src_root = cwd.join(&src_root);
 
         let tmpdir = cwd.join(self.output_base_name());
@@ -2204,9 +2360,12 @@ actual:\n\
         create_dir_all(&tmpdir).unwrap();
 
         let host = &self.config.host;
-        let make = if host.contains("bitrig") || host.contains("dragonfly") ||
-            host.contains("freebsd") || host.contains("netbsd") ||
-            host.contains("openbsd") {
+        let make = if host.contains("bitrig")
+            || host.contains("dragonfly")
+            || host.contains("freebsd")
+            || host.contains("netbsd")
+            || host.contains("openbsd")
+        {
             "gmake"
         } else {
             "make"
@@ -2214,21 +2373,29 @@ actual:\n\
 
         let mut cmd = Command::new(make);
         cmd.current_dir(&self.testpaths.file)
-           .stdout(Stdio::piped())
-           .stderr(Stdio::piped())
-           .env("TARGET", &self.config.target)
-           .env("PYTHON", &self.config.docck_python)
-           .env("S", src_root)
-           .env("RUST_BUILD_STAGE", &self.config.stage_id)
-           .env("RUSTC", cwd.join(&self.config.rustc_path))
-           .env("RUSTDOC",
-               cwd.join(&self.config.rustdoc_path.as_ref().expect("--rustdoc-path passed")))
-           .env("TMPDIR", &tmpdir)
-           .env("LD_LIB_PATH_ENVVAR", dylib_env_var())
-           .env("HOST_RPATH_DIR", cwd.join(&self.config.compile_lib_path))
-           .env("TARGET_RPATH_DIR", cwd.join(&self.config.run_lib_path))
-           .env("LLVM_COMPONENTS", &self.config.llvm_components)
-           .env("LLVM_CXXFLAGS", &self.config.llvm_cxxflags);
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .env("TARGET", &self.config.target)
+            .env("PYTHON", &self.config.docck_python)
+            .env("S", src_root)
+            .env("RUST_BUILD_STAGE", &self.config.stage_id)
+            .env("RUSTC", cwd.join(&self.config.rustc_path))
+            .env(
+                "RUSTDOC",
+                cwd.join(
+                    &self
+                        .config
+                        .rustdoc_path
+                        .as_ref()
+                        .expect("--rustdoc-path passed"),
+                ),
+            )
+            .env("TMPDIR", &tmpdir)
+            .env("LD_LIB_PATH_ENVVAR", dylib_env_var())
+            .env("HOST_RPATH_DIR", cwd.join(&self.config.compile_lib_path))
+            .env("TARGET_RPATH_DIR", cwd.join(&self.config.run_lib_path))
+            .env("LLVM_COMPONENTS", &self.config.llvm_components)
+            .env("LLVM_CXXFLAGS", &self.config.llvm_cxxflags);
 
         if let Some(ref linker) = self.config.linker {
             cmd.env("RUSTC_LINKER", linker);
@@ -2258,25 +2425,33 @@ actual:\n\
             // MSYS doesn't like passing flags of the form `/foo` as it thinks it's
             // a path and instead passes `C:\msys64\foo`, so convert all
             // `/`-arguments to MSVC here to `-` arguments.
-            let cflags = self.config.cflags.split(' ').map(|s| s.replace("/", "-"))
-                                                 .collect::<Vec<_>>().join(" ");
+            let cflags = self
+                .config
+                .cflags
+                .split(' ')
+                .map(|s| s.replace("/", "-"))
+                .collect::<Vec<_>>()
+                .join(" ");
 
             cmd.env("IS_MSVC", "1")
-               .env("IS_WINDOWS", "1")
-               .env("MSVC_LIB", format!("'{}' -nologo", lib.display()))
-               .env("CC", format!("'{}' {}", self.config.cc, cflags))
-               .env("CXX", &self.config.cxx);
+                .env("IS_WINDOWS", "1")
+                .env("MSVC_LIB", format!("'{}' -nologo", lib.display()))
+                .env("CC", format!("'{}' {}", self.config.cc, cflags))
+                .env("CXX", &self.config.cxx);
         } else {
             cmd.env("CC", format!("{} {}", self.config.cc, self.config.cflags))
-               .env("CXX", format!("{} {}", self.config.cxx, self.config.cflags))
-               .env("AR", &self.config.ar);
+                .env("CXX", format!("{} {}", self.config.cxx, self.config.cflags))
+                .env("AR", &self.config.ar);
 
             if self.config.target.contains("windows") {
                 cmd.env("IS_WINDOWS", "1");
             }
         }
 
-        let output = cmd.spawn().and_then(read2_abbreviated).expect("failed to spawn `make`");
+        let output = cmd
+            .spawn()
+            .and_then(read2_abbreviated)
+            .expect("failed to spawn `make`");
         if !output.status.success() {
             let res = ProcRes {
                 status: output.status,
@@ -2340,13 +2515,11 @@ actual:\n\
             json::extract_rendered(&proc_res.stderr, &proc_res)
         };
 
-        let normalized_stderr =
-            self.normalize_output(&stderr, &self.props.normalize_stderr);
+        let normalized_stderr = self.normalize_output(&stderr, &self.props.normalize_stderr);
 
         let mut errors = 0;
         errors += self.compare_output(UI_STDOUT, &normalized_stdout, &expected_stdout);
         errors += self.compare_output(UI_STDERR, &normalized_stderr, &expected_stderr);
-
 
         if self.config.rustfix_coverage {
             // Find out which tests have `MachineApplicable` suggestions but are missing
@@ -2357,32 +2530,34 @@ actual:\n\
             let suggestions = get_suggestions_from_json(
                 &proc_res.stderr,
                 &HashSet::new(),
-                Filter::MachineApplicableOnly
-            ).unwrap_or_default();
+                Filter::MachineApplicableOnly,
+            )
+            .unwrap_or_default();
             if suggestions.len() > 0
                 && !self.props.run_rustfix
-                && !self.props.rustfix_only_machine_applicable {
-                    let mut coverage_file_path = self.config.build_base.clone();
-                    coverage_file_path.push("rustfix_missing_coverage.txt");
-                    debug!("coverage_file_path: {}", coverage_file_path.display());
+                && !self.props.rustfix_only_machine_applicable
+            {
+                let mut coverage_file_path = self.config.build_base.clone();
+                coverage_file_path.push("rustfix_missing_coverage.txt");
+                debug!("coverage_file_path: {}", coverage_file_path.display());
 
-                    let file_ref = get_or_create_coverage_file(&coverage_file_path, || {
-                        OpenOptions::new()
-                            .create(true)
-                            .write(true)
-                            .truncate(true)
-                            .open(coverage_file_path.as_path())
-                            .expect("could not create or open file")
-                    });
-                    let mut file = file_ref.lock().unwrap();
-    
-                    if writeln!(file, "{}", self.testpaths.file.display())
-                        .and_then(|_| file.sync_data())
-                        .is_err()
-                    {
-                        panic!("couldn't write to {}", coverage_file_path.display());
-                    }
+                let file_ref = get_or_create_coverage_file(&coverage_file_path, || {
+                    OpenOptions::new()
+                        .create(true)
+                        .write(true)
+                        .truncate(true)
+                        .open(coverage_file_path.as_path())
+                        .expect("could not create or open file")
+                });
+                let mut file = file_ref.lock().unwrap();
+
+                if writeln!(file, "{}", self.testpaths.file.display())
+                    .and_then(|_| file.sync_data())
+                    .is_err()
+                {
+                    panic!("couldn't write to {}", coverage_file_path.display());
                 }
+            }
         }
 
         if self.props.run_rustfix {
@@ -2398,7 +2573,8 @@ actual:\n\
                 } else {
                     Filter::Everything
                 },
-            ).expect("Could not retrieve suggestions from JSON");
+            )
+            .expect("Could not retrieve suggestions from JSON");
             let fixed_code = apply_suggestions(&unfixed_code, &suggestions).expect(&format!(
                 "failed to apply suggestions for {:?} with rustfix",
                 self.testpaths.file
@@ -2414,8 +2590,10 @@ actual:\n\
 
         if errors > 0 {
             println!("To update references, rerun the tests and pass the `--bless` flag");
-            let relative_path_to_file =
-                self.testpaths.relative_dir.join(self.testpaths.file.file_name().unwrap());
+            let relative_path_to_file = self
+                .testpaths
+                .relative_dir
+                .join(self.testpaths.file.file_name().unwrap());
             println!(
                 "To only update this specific test, also pass `--test-args {}`",
                 relative_path_to_file.display(),
@@ -2473,13 +2651,14 @@ actual:\n\
 
     fn check_mir_dump(&self) {
         let mut test_file_contents = String::new();
-        fs::File::open(self.testpaths.file.clone()).unwrap()
-                                                   .read_to_string(&mut test_file_contents)
-                                                   .unwrap();
-        if let Some(idx) =  test_file_contents.find("// END RUST SOURCE") {
+        fs::File::open(self.testpaths.file.clone())
+            .unwrap()
+            .read_to_string(&mut test_file_contents)
+            .unwrap();
+        if let Some(idx) = test_file_contents.find("// END RUST SOURCE") {
             let (_, tests_text) = test_file_contents.split_at(idx + "// END_RUST SOURCE".len());
             let tests_text_str = String::from(tests_text);
-            let mut curr_test : Option<&str> = None;
+            let mut curr_test: Option<&str> = None;
             let mut curr_test_contents = vec![ExpectedLine::Elision];
             for l in tests_text_str.lines() {
                 debug!("line: {:?}", l);
@@ -2513,9 +2692,15 @@ actual:\n\
         let output_time = t(output_file);
         let source_time = t(source_file);
         if source_time > output_time {
-            debug!("source file time: {:?} output file time: {:?}", source_time, output_time);
-            panic!("test source file `{}` is newer than potentially stale output file `{}`.",
-                   source_file.display(), test_name);
+            debug!(
+                "source file time: {:?} output file time: {:?}",
+                source_time, output_time
+            );
+            panic!(
+                "test source file `{}` is newer than potentially stale output file `{}`.",
+                source_file.display(),
+                test_name
+            );
         }
     }
 
@@ -2526,8 +2711,10 @@ actual:\n\
         debug!("comparing the contests of: {:?}", output_file);
         debug!("with: {:?}", expected_content);
         if !output_file.exists() {
-            panic!("Output file `{}` from test does not exist",
-                   output_file.into_os_string().to_string_lossy());
+            panic!(
+                "Output file `{}` from test does not exist",
+                output_file.into_os_string().to_string_lossy()
+            );
         }
         self.check_mir_test_timestamp(test_name, &output_file);
 
@@ -2535,13 +2722,16 @@ actual:\n\
         let mut dumped_string = String::new();
         dumped_file.read_to_string(&mut dumped_string).unwrap();
         let mut dumped_lines = dumped_string.lines().filter(|l| !l.is_empty());
-        let mut expected_lines = expected_content.iter().filter(|&l| {
-            if let &ExpectedLine::Text(l) = l {
-                !l.is_empty()
-            } else {
-                true
-            }
-        }).peekable();
+        let mut expected_lines = expected_content
+            .iter()
+            .filter(|&l| {
+                if let &ExpectedLine::Text(l) = l {
+                    !l.is_empty()
+                } else {
+                    true
+                }
+            })
+            .peekable();
 
         let compare = |expected_line, dumped_line| {
             let e_norm = normalize_mir_line(expected_line);
@@ -2552,27 +2742,28 @@ actual:\n\
         };
 
         let error = |expected_line, extra_msg| {
-            let normalize_all = dumped_string.lines()
-                                             .map(nocomment_mir_line)
-                                             .filter(|l| !l.is_empty())
-                                             .collect::<Vec<_>>()
-                                             .join("\n");
+            let normalize_all = dumped_string
+                .lines()
+                .map(nocomment_mir_line)
+                .filter(|l| !l.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
             let f = |l: &ExpectedLine<_>| match l {
                 &ExpectedLine::Elision => "... (elided)".into(),
-                &ExpectedLine::Text(t) => t
+                &ExpectedLine::Text(t) => t,
             };
-            let expected_content = expected_content.iter()
-                                                   .map(|l| f(l))
-                                                   .collect::<Vec<_>>()
-                                                   .join("\n");
-            panic!("Did not find expected line, error: {}\n\
+            let expected_content = expected_content
+                .iter()
+                .map(|l| f(l))
+                .collect::<Vec<_>>()
+                .join("\n");
+            panic!(
+                "Did not find expected line, error: {}\n\
                    Actual Line: {:?}\n\
                    Expected:\n{}\n\
                    Actual:\n{}",
-                   extra_msg,
-                   expected_line,
-                   expected_content,
-                   normalize_all);
+                extra_msg, expected_line, expected_content, normalize_all
+            );
         };
 
         // We expect each non-empty line to appear consecutively, non-consecutive lines
@@ -2588,11 +2779,16 @@ actual:\n\
 
                     if !compare(expected_line, dumped_line) {
                         error!("{:?}", start_block_line);
-                        error(expected_line,
-                              format!("Mismatch in lines\nCurrnt block: {}\nExpected Line: {:?}",
-                                      start_block_line.unwrap_or("None"), dumped_line));
+                        error(
+                            expected_line,
+                            format!(
+                                "Mismatch in lines\nCurrnt block: {}\nExpected Line: {:?}",
+                                start_block_line.unwrap_or("None"),
+                                dumped_line
+                            ),
+                        );
                     }
-                },
+                }
                 Some(&ExpectedLine::Elision) => {
                     // skip any number of elisions in a row.
                     while let Some(&&ExpectedLine::Elision) = expected_lines.peek() {
@@ -2613,8 +2809,8 @@ actual:\n\
                             error(expected_line, "ran out of mir dump to match against".into());
                         }
                     }
-                },
-                None => {},
+                }
+                None => {}
             }
         }
     }
@@ -2666,10 +2862,11 @@ actual:\n\
             normalized = normalized.replace("\\n", "\n");
         }
 
-        normalized = normalized.replace("\\\\", "\\") // denormalize for paths on windows
-              .replace("\\", "/") // normalize for paths on windows
-              .replace("\r\n", "\n") // normalize for linebreaks on windows
-              .replace("\t", "\\t"); // makes tabs visible
+        normalized = normalized
+            .replace("\\\\", "\\") // denormalize for paths on windows
+            .replace("\\", "/") // normalize for paths on windows
+            .replace("\r\n", "\n") // normalize for linebreaks on windows
+            .replace("\t", "\\t"); // makes tabs visible
         for rule in custom_rules {
             let re = Regex::new(&rule.0).expect("bad regex in custom normalization rule");
             normalized = re.replace_all(&normalized, &rule.1[..]).into_owned();
@@ -2678,8 +2875,7 @@ actual:\n\
     }
 
     fn expected_output_path(&self, kind: &str) -> PathBuf {
-        let mut path =
-            expected_output_path(&self.testpaths, self.revision, kind);
+        let mut path = expected_output_path(&self.testpaths, self.revision, kind);
 
         if !path.exists() {
             path = expected_output_path(&self.testpaths, self.revision, kind);
@@ -2696,16 +2892,21 @@ actual:\n\
         let mut result = String::new();
         match File::open(path).and_then(|mut f| f.read_to_string(&mut result)) {
             Ok(_) => result,
-            Err(e) => {
-                self.fatal(&format!("failed to load expected output from `{}`: {}",
-                                    path.display(), e))
-            }
+            Err(e) => self.fatal(&format!(
+                "failed to load expected output from `{}`: {}",
+                path.display(),
+                e
+            )),
         }
     }
 
     fn load_expected_output_from_path(&self, path: &Path) -> Result<String, String> {
         fs::read_to_string(path).map_err(|err| {
-            format!("failed to load expected output from `{}`: {}", path.display(), err)
+            format!(
+                "failed to load expected output from `{}`: {}",
+                path.display(),
+                err
+            )
         })
     }
 
@@ -2731,9 +2932,9 @@ actual:\n\
                 println!("diff of {}:\n", kind);
                 for diff in diff::lines(expected, actual) {
                     match diff {
-                        diff::Result::Left(l)    => println!("-{}", l),
+                        diff::Result::Left(l) => println!("-{}", l),
                         diff::Result::Both(l, _) => println!(" {}", l),
-                        diff::Result::Right(r)   => println!("+{}", r),
+                        diff::Result::Right(r) => println!("+{}", r),
                     }
                 }
             }
@@ -2746,11 +2947,7 @@ actual:\n\
 
         let mut files = vec![output_file];
         if self.config.bless {
-            files.push(expected_output_path(
-                self.testpaths,
-                self.revision,
-                kind,
-            ));
+            files.push(expected_output_path(self.testpaths, self.revision, kind));
         }
 
         for output_file in &files {
@@ -2770,7 +2967,11 @@ actual:\n\
         for output_file in files {
             println!("Actual {} saved to {}", kind, output_file.display());
         }
-        if self.config.bless { 0 } else { 1 }
+        if self.config.bless {
+            0
+        } else {
+            1
+        }
     }
 }
 
@@ -2791,7 +2992,8 @@ impl ProcRes {
         if let Some(e) = err {
             println!("\nerror: {}", e);
         }
-        print!("\
+        print!(
+            "\
             status: {}\n\
             command: {}\n\
             stdout:\n\
@@ -2803,8 +3005,8 @@ impl ProcRes {
             {}\n\
             ------------------------------------------\n\
             \n",
-               self.status, self.cmdline, self.stdout,
-               self.stderr);
+            self.status, self.cmdline, self.stdout, self.stderr
+        );
         // Use resume_unwind instead of panic!() to prevent a panic message + backtrace from
         // compiletest, which is unnecessary noise.
         std::panic::resume_unwind(Box::new(()));
@@ -2819,7 +3021,7 @@ enum TargetLocation {
 #[derive(Clone, PartialEq, Eq)]
 enum ExpectedLine<T: AsRef<str>> {
     Elision,
-    Text(T)
+    Text(T),
 }
 
 enum AllowUnused {
@@ -2829,7 +3031,7 @@ enum AllowUnused {
 
 impl<T> fmt::Debug for ExpectedLine<T>
 where
-    T: AsRef<str> + fmt::Debug
+    T: AsRef<str> + fmt::Debug,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         if let &ExpectedLine::Text(ref t) = self {
@@ -2854,8 +3056,8 @@ fn nocomment_mir_line(line: &str) -> &str {
 }
 
 fn read2_abbreviated(mut child: Child) -> io::Result<Output> {
-    use std::mem::replace;
     use read2::read2;
+    use std::mem::replace;
 
     const HEAD_LEN: usize = 160 * 1024;
     const TAIL_LEN: usize = 256 * 1024;
@@ -2866,7 +3068,7 @@ fn read2_abbreviated(mut child: Child) -> io::Result<Output> {
             head: Vec<u8>,
             skipped: usize,
             tail: Box<[u8]>,
-        }
+        },
     }
 
     impl ProcOutput {
@@ -2882,9 +3084,17 @@ fn read2_abbreviated(mut child: Child) -> io::Result<Output> {
                     let mut head = replace(bytes, Vec::new());
                     head.truncate(HEAD_LEN);
                     let skipped = new_len - HEAD_LEN - TAIL_LEN;
-                    ProcOutput::Abbreviated { head, skipped, tail }
+                    ProcOutput::Abbreviated {
+                        head,
+                        skipped,
+                        tail,
+                    }
                 }
-                ProcOutput::Abbreviated { ref mut skipped, ref mut tail, .. } => {
+                ProcOutput::Abbreviated {
+                    ref mut skipped,
+                    ref mut tail,
+                    ..
+                } => {
                     *skipped += data.len();
                     if data.len() <= TAIL_LEN {
                         tail[..data.len()].copy_from_slice(data);
@@ -2901,7 +3111,11 @@ fn read2_abbreviated(mut child: Child) -> io::Result<Output> {
         fn into_bytes(self) -> Vec<u8> {
             match self {
                 ProcOutput::Full(bytes) => bytes,
-                ProcOutput::Abbreviated { mut head, skipped, tail } => {
+                ProcOutput::Abbreviated {
+                    mut head,
+                    skipped,
+                    tail,
+                } => {
                     write!(&mut head, "\n\n<<<<<< SKIPPED {} BYTES >>>>>>\n\n", skipped).unwrap();
                     head.extend_from_slice(&tail);
                     head
@@ -2914,10 +3128,14 @@ fn read2_abbreviated(mut child: Child) -> io::Result<Output> {
     let mut stderr = ProcOutput::Full(Vec::new());
 
     drop(child.stdin.take());
-    read2(child.stdout.take().unwrap(), child.stderr.take().unwrap(), &mut |is_stdout, data, _| {
-        if is_stdout { &mut stdout } else { &mut stderr }.extend(data);
-        data.clear();
-    })?;
+    read2(
+        child.stdout.take().unwrap(),
+        child.stderr.take().unwrap(),
+        &mut |is_stdout, data, _| {
+            if is_stdout { &mut stdout } else { &mut stderr }.extend(data);
+            data.clear();
+        },
+    )?;
     let status = child.wait()?;
 
     Ok(Output {

--- a/src/uidiff.rs
+++ b/src/uidiff.rs
@@ -15,19 +15,17 @@ pub fn diff_lines(actual: &str, expected: &str) -> Vec<String> {
     // mega simplistic diff algorithm that just prints the things added/removed
     zip_all(actual.lines(), expected.lines())
         .enumerate()
-        .filter_map(|(i, (a, e))| {
-            match (a, e) {
-                (Some(a), Some(e)) => {
-                    if lines_match(e, a) {
-                        None
-                    } else {
-                        Some(format!("{:3} - |{}|\n    + |{}|\n", i, e, a))
-                    }
+        .filter_map(|(i, (a, e))| match (a, e) {
+            (Some(a), Some(e)) => {
+                if lines_match(e, a) {
+                    None
+                } else {
+                    Some(format!("{:3} - |{}|\n    + |{}|\n", i, e, a))
                 }
-                (Some(a), None) => Some(format!("{:3} -\n    + |{}|\n", i, a)),
-                (None, Some(e)) => Some(format!("{:3} - |{}|\n    +\n", i, e)),
-                (None, None) => panic!("Cannot get here"),
             }
+            (Some(a), None) => Some(format!("{:3} -\n    + |{}|\n", i, a)),
+            (None, Some(e)) => Some(format!("{:3} - |{}|\n    +\n", i, e)),
+            (None, None) => panic!("Cannot get here"),
         })
         .collect()
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::env;
 use common::Config;
+use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
@@ -59,7 +59,7 @@ pub fn matches_os(triple: &str, name: &str) -> bool {
     // For the wasm32 bare target we ignore anything also ignored on emscripten
     // and then we also recognize `wasm32-bare` as the os for the target
     if triple == "wasm32-unknown-unknown" {
-        return name == "emscripten" || name == "wasm32-bare"
+        return name == "emscripten" || name == "wasm32-bare";
     }
     for &(triple_os, os) in OS_TABLE {
         if triple.contains(triple_os) {

--- a/tests/bless.rs
+++ b/tests/bless.rs
@@ -3,8 +3,8 @@
 extern crate compiletest_rs as compiletest;
 
 mod test_support;
-use test_support::{testsuite, TestsuiteBuilder, GLOBAL_ROOT};
 use compiletest::Config;
+use test_support::{testsuite, TestsuiteBuilder, GLOBAL_ROOT};
 
 fn setup(mode: &str) -> (Config, TestsuiteBuilder) {
     let builder = testsuite(mode);
@@ -23,18 +23,20 @@ fn test_bless_new_file() {
     config.bless = true;
 
     builder.mk_file(
-              "foobar.rs",
-              r#"
+        "foobar.rs",
+        r#"
                   #[warn(unused_variables)]
                   fn main() {
                       let abc = "foobar";
                   }
               "#,
-          );
+    );
     compiletest::run_tests(&config);
 
     // Blessing should cause the stderr to be created directly
-    assert!(builder.file_contents("foobar.stderr").contains("unused variable"));
+    assert!(builder
+        .file_contents("foobar.stderr")
+        .contains("unused variable"));
 
     // And a second run of the tests, with blessing disabled should work just fine
     config.bless = false;
@@ -76,8 +78,12 @@ fn test_bless_update_file() {
     compiletest::run_tests(&config);
 
     // Blessing should cause the stderr to be created directly
-    assert!(builder.file_contents("foobar2.stderr").contains("unused variable"));
-    assert!(builder.file_contents("foobar2.stderr").contains("foobar_update"));
+    assert!(builder
+        .file_contents("foobar2.stderr")
+        .contains("unused variable"));
+    assert!(builder
+        .file_contents("foobar2.stderr")
+        .contains("foobar_update"));
 
     // And a second run of the tests, with blessing disabled should work just fine
     config.bless = false;

--- a/tests/test_support/mod.rs
+++ b/tests/test_support/mod.rs
@@ -2,12 +2,11 @@
 //!
 //! Inspired by cargo's `cargo-test-support` crate:
 //! https://github.com/rust-lang/cargo/tree/master/crates/cargo-test-support
+use std::cell::RefCell;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::cell::RefCell;
 use std::sync::atomic::{AtomicUsize, Ordering};
-
 
 static COMPILETEST_INTEGRATION_TEST_DIR: &str = "cit";
 
@@ -44,14 +43,13 @@ impl TestsuiteBuilder {
 
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
         TEST_ID.with(|n| *n.borrow_mut() = Some(id));
-        let root = GLOBAL_ROOT.join(format!("id{}", TEST_ID.with(|n|n.borrow().unwrap()))).join(mode);
+        let root = GLOBAL_ROOT
+            .join(format!("id{}", TEST_ID.with(|n| n.borrow().unwrap())))
+            .join(mode);
         root.mkdir_p();
 
-        Self {
-            root,
-        }
+        Self { root }
     }
-
 
     /// Creates a new file to be used for the integration test
     pub fn mk_file(&self, path: &str, body: &str) {


### PR DESCRIPTION
- [NFC] cargo fmt
- Add optional preprocessing before FileCheck

This allows us to implement tests in https://github.com/aya-rs/bpf-linker that invoke bpftool on our object files, and then run FileCheck on the output.
