### PR TITLE
Add support for using revisions with FileCheck

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -1891,10 +1891,18 @@ actual:\n\
         } else {
             output
         };
+        let prefixes = if let Some(rev) = self.revision {
+            format!("CHECK,{}", rev)
+        } else {
+            "CHECK".to_string()
+        };
         let mut filecheck = Command::new(self.config.llvm_filecheck.as_ref().unwrap());
         filecheck
             .arg("--input-file")
             .arg(output)
+            .arg("--allow-unused-prefixes")
+            .arg("--check-prefixes")
+            .arg(&prefixes)
             .arg(&self.testpaths.file);
         let proc_res = self.compose_and_run(filecheck, "", None, None);
         if !proc_res.status.success() {


### PR DESCRIPTION
This adds support for revisions to FileCheck checks, using the same syntax as upstream compiletest, for example:

```
// revisions: exported not_exported
...
// CHECK,exported: .globl dep_no_mangle
...
// public symbols are not exported
// CHECK,not_exported-NOT: .globl local_public
```