### PR TITLE
ci: Fix workflow errors

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -373,7 +373,6 @@ impl Config {
 #[cfg(feature = "tmp")]
 mod config_tempdir {
     use std::ops;
-    use tempfile;
 
     pub struct ConfigWithTemp {
         pub config: super::Config,

--- a/src/json.rs
+++ b/src/json.rs
@@ -10,7 +10,6 @@
 
 use errors::{Error, ErrorKind};
 use runtest::ProcRes;
-use serde_json;
 use std::path::Path;
 use std::str::FromStr;
 

--- a/src/read2.rs
+++ b/src/read2.rs
@@ -35,7 +35,6 @@ mod imp {
 
 #[cfg(unix)]
 mod imp {
-    use libc;
     use std::io;
     use std::io::prelude::*;
     use std::mem;

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -14,7 +14,6 @@ use common::{Assembly, Incremental, MirOpt, RunMake, Ui};
 use common::{Codegen, CodegenUnits, DebugInfoGdb, DebugInfoLldb, Rustdoc};
 use common::{CompileFail, ParseFail, Pretty, RunFail, RunPass, RunPassValgrind};
 use common::{Config, TestPaths};
-use diff;
 use errors::{self, Error, ErrorKind};
 use filetime::FileTime;
 use header::TestProps;

--- a/test-project/tests/pretty/macro.pp
+++ b/test-project/tests/pretty/macro.pp
@@ -8,6 +8,6 @@ extern crate std;
 //@pretty-mode:expanded
 //@pp-exact:macro.pp
 
-macro_rules! square { ($x : expr) => { $x * $x } ; }
+macro_rules! square { ($x:expr) => { $x * $x }; }
 
 fn f() -> i8 { 5 * 5 }

--- a/test-project/tests/ui/dyn-keyword.stderr
+++ b/test-project/tests/ui/dyn-keyword.stderr
@@ -12,5 +12,5 @@ note: the lint level is defined here
 14 | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 


### PR DESCRIPTION
* Remove redundant imports. Rust nightly treats such as errors.
* Update the expected error message. The `dyn-keyword` test produces a slightly different message nowadays.
* Fix formatting in the pretty-mode test.