### PR TITLE
Switch from `winapi` to `windows_sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2"
 
 [target."cfg(windows)".dependencies]
 miow = "0.5"
-winapi = { version = "0.3", features = ["winerror"] }
+windows-sys = { version = "0.52", features = ["Win32"] }
 
 [features]
 tmp = ["tempfile"]

--- a/src/read2.rs
+++ b/src/read2.rs
@@ -106,7 +106,7 @@ mod imp {
 #[cfg(windows)]
 mod imp {
     extern crate miow;
-    extern crate winapi;
+    extern crate windows_sys;
 
     use std::io;
     use std::os::windows::prelude::*;
@@ -116,7 +116,8 @@ mod imp {
     use self::miow::iocp::{CompletionPort, CompletionStatus};
     use self::miow::pipe::NamedPipe;
     use self::miow::Overlapped;
-    use self::winapi::shared::winerror::ERROR_BROKEN_PIPE;
+
+    use self::windows_sys::Win32::Foundation::ERROR_BROKEN_PIPE;
 
     struct Pipe<'a> {
         dst: &'a mut Vec<u8>,


### PR DESCRIPTION
`windows` is the modern version of `winapi` that is maintained by
Microsoft.
