### PR TITLE
Add option to customize expected rustc exit code for compile tests

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -239,6 +239,9 @@ pub struct Config {
     /// as a header.
     pub strict_headers: bool,
 
+    /// Expected exit code for compile tests. Defaults to expecting `1` if unset.
+    pub compile_test_exit_code: Option<i32>,
+
     // Configuration for various run-make tests frobbing things like C compilers
     // or querying about various LLVM component information.
     pub cc: String,
@@ -464,6 +467,7 @@ impl Default for Config {
             quiet: false,
             color: ColorConfig::AutoColor,
             remote_test_client: None,
+            compile_test_exit_code: None,
             cc: "cc".to_string(),
             cxx: "cxx".to_string(),
             cflags: "cflags".to_string(),

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -229,9 +229,12 @@ impl<'test> TestCx<'test> {
     }
 
     fn check_correct_failure_status(&self, proc_res: &ProcRes) {
-        // The value the rust runtime returns on failure
-        const RUST_ERR: i32 = 1;
-        if proc_res.status.code() != Some(RUST_ERR) {
+        // The value the rust runtime returns on normal compile failure
+        const DEFAULT_RUST_ERR: i32 = 1;
+
+        let expected = self.config.compile_test_exit_code.unwrap_or(DEFAULT_RUST_ERR);
+
+        if proc_res.status.code() != Some(expected) {
             self.fatal_proc_rec(
                 &format!("failure produced the wrong error: {}", proc_res.status),
                 proc_res,


### PR DESCRIPTION
Since Rust 1.81 [rustc now aborts](https://github.com/rust-lang/rust/commit/e3ffbbd2263059fd7d11881540c214aeb000a7d3) when lints report errors, meaning the exit code is 101.
This is causing the compile tests of the custom crown linter in the servo project to fail (See discussion in https://github.com/servo/servo/pull/34270).
Allowing the user to specify a custom exit code, allows custom linter authors to override the expected error code.

Fixes #295

