### PR TITLE
Fix nightly-feature-rustc test build

### DIFF
--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "rustc", feature(rustc_private))]
+
 extern crate compiletest_rs as compiletest;
 
 use std::env;

--- a/tests/bless.rs
+++ b/tests/bless.rs
@@ -1,5 +1,7 @@
 //! Tests for the `bless` option
 
+#![cfg_attr(feature = "rustc", feature(rustc_private))]
+
 extern crate compiletest_rs as compiletest;
 
 mod test_support;


### PR DESCRIPTION
Since integration tests are built as separate crates, they also need
`feature(rustc_private)`.
