### PR TITLE
Handle empty lib path

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -290,6 +290,10 @@ where
     if !lib_paths.as_ref().is_empty() {
         for p in env::split_paths(lib_paths.as_ref()) {
             let p = p.to_str().unwrap();
+            // Skip empty path, as otherwise we will just append "-L" without any path.
+            if p.is_empty() {
+                continue;
+            }
             assert!(!p.contains(' '), "spaces in paths not supported: {}", p);
             flags += " -L ";
             flags += p;


### PR DESCRIPTION
If lib path (LD_LIBRARY_PATH on Linux) is empty, currently a "-L" flag will be added without any path supplied. This can cause unintended consequence, e.g. the next flag may be parsed as a path instead.

The existing check handles the case where `lib_paths` is empty, but not when it contains an empty component. If LD_LIBRARY_PATH is set to empty and aux_path is present, the logic in compose_and_run in runtest.rs can change it to `{aux_path}:{LD_LIBRARY_PATH}`, causing it to have an empty component but not fully empty.